### PR TITLE
Add word definition feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,20 @@
       line-height: 1;
     }
 
+    #definitionToggle {
+      display: none;
+      position: absolute;
+      top: 15px;
+      right: 105px;
+      font-size: 20px;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 5px;
+      color: var(--text-color-light);
+      line-height: 1;
+    }
+
     h1 {
       color: var(--text-color-light);
       margin-bottom: 5px;
@@ -117,6 +131,22 @@
       position: absolute;
       top: 100px;
       left: 20px;
+      width: 260px;
+      max-height: 70vh;
+      overflow-y: auto;
+      background: var(--bg-color);
+      padding: 10px;
+      border-radius: 8px;
+      box-shadow:
+        inset 2px 2px 5px var(--shadow-color-dark),
+        inset -2px -2px 5px var(--shadow-color-light);
+      transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+
+    #definitionBox {
+      position: absolute;
+      top: 100px;
+      right: 20px;
       width: 260px;
       max-height: 70vh;
       overflow-y: auto;
@@ -530,6 +560,10 @@
         display: block;
       }
 
+      #definitionToggle {
+        display: block;
+      }
+
       #historyBox {
         position: fixed;
         bottom: 0;
@@ -546,8 +580,39 @@
         z-index: 50;
       }
 
+      #definitionBox {
+        display: none;
+        position: fixed;
+        bottom: 0;
+        right: 0;
+        width: 100%;
+        max-height: 0;
+        overflow-y: hidden;
+        border-radius: 0;
+        padding: 0;
+        box-shadow: none;
+        background: var(--bg-color);
+        opacity: 0;
+        transform: translateY(100%);
+        z-index: 50;
+      }
+
       body.history-open #historyBox {
         max-height: 50vh;
+        max-width: calc(98% - 20px);
+        padding: 8px;
+        overflow-y: auto;
+        border-radius: 0;
+        box-shadow: inset 2px 2px 4px var(--shadow-color-dark),
+                    inset -2px -2px 4px var(--shadow-color-light);
+        opacity: 1;
+        transform: translateY(0);
+        transition: transform 0.3s ease, opacity 0.3s ease;
+      }
+
+      body.definition-open #definitionBox {
+        display: block;
+        max-height: 40vh;
         max-width: calc(98% - 20px);
         padding: 8px;
         overflow-y: auto;
@@ -654,6 +719,7 @@
 
     <!-- Dark Mode & History Toggle Buttons -->
     <button id="historyToggle" title="Show/Hide History">📜</button>
+    <button id="definitionToggle" title="Show/Hide Definition">📖</button>
     <button id="darkModeToggle" title="Toggle Dark Mode">🌙</button>
 
     <!-- Game History Panel -->
@@ -664,6 +730,7 @@
 
     <!-- Leaderboard -->
     <div id="leaderboard"></div>
+    <div id="definitionBox"></div>
 
     <h1>WordleWithFriends</h1>
 
@@ -866,6 +933,8 @@
     const keyboard = document.getElementById('keyboard');
     const darkModeToggle = document.getElementById('darkModeToggle');
     const historyToggle = document.getElementById('historyToggle');
+    const definitionToggle = document.getElementById('definitionToggle');
+    const definitionBox = document.getElementById('definitionBox');
     const holdReset = document.getElementById('holdReset');
     const holdResetProgress = document.getElementById('holdResetProgress');
     const holdResetText = document.getElementById('holdResetText');
@@ -886,6 +955,11 @@
     // --- History Toggle (mobile only) ---
     historyToggle.addEventListener('click', () => {
       document.body.classList.toggle('history-open');
+    });
+
+    // --- Definition Toggle (mobile only) ---
+    definitionToggle.addEventListener('click', () => {
+      document.body.classList.toggle('definition-open');
     });
 
     // --- Create Board ---
@@ -1076,6 +1150,13 @@
 
           updateResetButton();
 
+          if (state.is_over && state.definition) {
+            definitionBox.textContent = `${state.target_word.toUpperCase()} \u2013 ${state.definition}`;
+          } else {
+            definitionBox.textContent = '';
+            document.body.classList.remove('definition-open');
+          }
+
           const haveMy = activeEmojis.includes(myEmoji);
           if (!myEmoji || !haveMy || showEmojiModalOnNextFetch) {
             showEmojiModal(activeEmojis);
@@ -1119,6 +1200,9 @@
           }
           if (resp.over && !resp.won) {
             messageEl.textContent = "Game Over! The word was " + resp.state.target_word.toUpperCase();
+          }
+          if (resp.over && resp.state.definition) {
+            definitionBox.textContent = `${resp.state.target_word.toUpperCase()} \u2013 ${resp.state.definition}`;
           }
         } else {
           messageEl.textContent = resp.msg;


### PR DESCRIPTION
## Summary
- persist a `definition` value in the game state
- fetch a definition from dictionaryapi.dev on game over
- reset the cached definition when starting a new game
- expose the definition via `/state` and `/guess` responses
- add UI elements for toggling and showing definitions
- show the definition after the game ends

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436a72daa4832f80b6018f41f2b7b3