### PR TITLE
UI tweaks for spacing and menu placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
 
     #optionsMenu {
       position: fixed;
-      bottom: 70px;
+      top: 60px;
       right: 20px;
       background: var(--bg-color);
       padding: 10px;
@@ -371,11 +371,12 @@
     /* ─── Message Area ─── */
     #message {
       font-size: 18px;
-      margin-top: 20px;
-      min-height: 25px;
+      margin: 10px 0 0 0;
+      min-height: 0;
       color: var(--text-color);
       font-weight: 500;
       transition: color 0.3s;
+      visibility: hidden;
     }
     #messagePopup {
       display: none;
@@ -395,7 +396,7 @@
     /* ─── Keyboard ─── */
     #keyboard {
       display: inline-block;
-      margin-top: 15px;
+      margin-top: 5px;
     }
 
     .keyboard-row {
@@ -1060,6 +1061,8 @@
       guessInput.style.display = 'none';
       submitButton.style.display = 'none';
       messageEl.style.display = 'none';
+    } else {
+      messageEl.style.visibility = 'hidden';
     }
 
     function showMessage(msg) {
@@ -1069,6 +1072,7 @@
         setTimeout(() => { messagePopup.style.display = 'none'; }, 2000);
       } else {
         messageEl.textContent = msg;
+        messageEl.style.visibility = msg ? 'visible' : 'hidden';
       }
     }
 


### PR DESCRIPTION
## Summary
- reduce spacing between board and keyboard by tightening message area
- show/hide desktop messages and start hidden
- move options menu near the gear icon

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444c39d7d4832f96ed28d914b26611