### PR TITLE
Fix mobile keyboard and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,7 @@
     #titleBar h1 {
       flex: 1;
       margin: 0 10px;
+      text-align: center;
     }
 
     /* ─── History Panel ─── */
@@ -1415,8 +1416,9 @@
     }
 
     // --- Keyboard Input (Physical & On-screen) ---
-    keyboard.addEventListener('click', function (event) {
+    function handleVirtualKey(event) {
       if (event.target.classList.contains('key') && !guessInput.disabled && !isAnimating) {
+        event.preventDefault();
         const key = event.target.dataset.key;
         const currentValue = guessInput.value;
         if (key === 'Enter') {
@@ -1429,7 +1431,9 @@
         guessInput.focus();
         updateBoardFromTyping();
       }
-    });
+    }
+    keyboard.addEventListener('click', handleVirtualKey);
+    keyboard.addEventListener('touchstart', handleVirtualKey);
     submitButton.addEventListener('click', submitGuessHandler);
     guessInput.addEventListener('input', function () {
       this.value = this.value.replace(/[^a-zA-Z]/g, '').toUpperCase().slice(0, 5);
@@ -1470,13 +1474,28 @@
       }
     });
 
-    // --- On initial load ---
-    applyDarkModePreference();
-    createBoard();
-    fetchState();
-    setInterval(fetchState, 2000);
-    document.addEventListener("keydown", onActivity);
-    document.addEventListener("click", onActivity);
+      function repositionResetButton() {
+        const resetWrapper = document.getElementById('resetWrapper');
+        const titleBar = document.getElementById('titleBar');
+        const inputArea = document.getElementById('inputArea');
+        if (window.innerWidth <= 600) {
+          if (!titleBar.contains(resetWrapper)) {
+            titleBar.insertBefore(resetWrapper, titleBar.firstChild);
+          }
+        } else if (!inputArea.contains(resetWrapper)) {
+          inputArea.appendChild(resetWrapper);
+        }
+      }
+
+      // --- On initial load ---
+      applyDarkModePreference();
+      createBoard();
+      repositionResetButton();
+      fetchState();
+      setInterval(fetchState, 2000);
+      document.addEventListener("keydown", onActivity);
+      document.addEventListener("click", onActivity);
+      window.addEventListener('resize', repositionResetButton);
 
     // --- updateVH() to keep body height locked under the keyboard ---
     function updateVH() {


### PR DESCRIPTION
## Summary
- position reset button inside the title bar on mobile only
- keep reset button next to the Guess button on larger screens
- center the page title text
- handle touch events for the on‑screen keyboard to avoid getting stuck

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68447357a9e8832f823486c85f3ad312