### PR TITLE
Add persistent dictionary reset test

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -394,6 +394,54 @@ def test_fetch_definition_exception(monkeypatch, server_env):
     assert definition is None
 
 
+def test_definition_available_after_game_over(monkeypatch, server_env):
+    server, request = server_env
+
+    monkeypatch.setattr(server, 'fetch_definition', lambda w: 'a fruit')
+
+    request.json = {'guess': server.target_word, 'emoji': '😀'}
+    request.remote_addr = '1'
+    resp = server.guess_word()
+
+    assert resp['over'] is True
+    assert resp['state']['definition'] == 'a fruit'
+    assert server.definition == 'a fruit'
+    assert server.last_word == server.target_word
+    assert server.last_definition == 'a fruit'
+
+    request.method = 'GET'
+    request.json = None
+    state = server.state()
+    assert state['definition'] == 'a fruit'
+
+def test_last_definition_persists_after_reset(monkeypatch, server_env):
+    server, request = server_env
+
+    monkeypatch.setattr(server, 'fetch_definition', lambda w: 'a fruit')
+    prev_word = server.target_word
+
+    request.json = {'guess': prev_word, 'emoji': '😀'}
+    request.remote_addr = '1'
+    resp = server.guess_word()
+
+    assert resp['over'] is True
+    assert server.last_word == prev_word
+    assert server.last_definition == 'a fruit'
+
+    monkeypatch.setattr(server.random, 'choice', lambda words: 'enter')
+    reset = server.reset_game()
+    assert reset['status'] == 'ok'
+    assert server.definition is None
+    assert server.last_word == prev_word
+    assert server.last_definition == 'a fruit'
+
+    request.method = 'GET'
+    request.json = None
+    state = server.state()
+    assert state['definition'] is None
+    assert state['last_word'] == prev_word
+    assert state['last_definition'] == 'a fruit'
+
 def test_save_and_load_round_trip(tmp_path, server_env, monkeypatch):
     server, _ = server_env
     game_file = tmp_path / 'game.json'


### PR DESCRIPTION
## Summary
- merge main into work
- fix merge conflict in `tests/test_server.py`
- ensure dictionary entries persist after reset

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844a1163118832f9eb04c8f598a7500