### PR TITLE
Add test for definition retrieval on game loss

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -415,6 +415,30 @@ def test_definition_available_after_game_over(monkeypatch, server_env):
     assert state['definition'] == 'a fruit'
 
 
+def test_definition_fetched_on_loss(monkeypatch, server_env):
+    server, request = server_env
+
+    monkeypatch.setattr(server, 'fetch_definition', lambda w: 'a fruit')
+    monkeypatch.setattr(server, 'MAX_ROWS', 1)
+
+    request.json = {'guess': 'enter', 'emoji': '😀'}
+    request.remote_addr = '1'
+    resp = server.guess_word()
+
+    assert resp['over'] is True
+    assert resp['won'] is False
+    assert server.is_over
+    assert resp['state']['definition'] == 'a fruit'
+    assert server.definition == 'a fruit'
+    assert server.last_word == server.target_word
+    assert server.last_definition == 'a fruit'
+
+    request.method = 'GET'
+    request.json = None
+    state = server.state()
+    assert state['definition'] == 'a fruit'
+
+
 def test_save_and_load_round_trip(tmp_path, server_env, monkeypatch):
     server, _ = server_env
     game_file = tmp_path / 'game.json'


### PR DESCRIPTION
## Summary
- test that dictionary definitions are retrieved when the game is lost

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a8f40004832fa083e39840186e6b