### PR TITLE
Improve desktop panels and add offline definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,13 @@
       color: var(--text-color-light);
     }
 
+    @media (min-width: 601px) {
+      #historyClose,
+      #definitionClose {
+        display: none;
+      }
+    }
+
     h1 {
       color: var(--text-color-light);
       margin-bottom: 5px;

--- a/offline_definitions.json
+++ b/offline_definitions.json
@@ -1,0 +1,7 @@
+{
+  "apple": "a fruit",
+  "enter": "to go or come into",
+  "crane": "a large bird or lifting machine",
+  "crate": "a large shipping container",
+  "trace": "a mark or sign left by something"
+}

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ import json
 import os
 import time
 import urllib.request
+import urllib.error
 
 app = Flask(__name__)
 app.secret_key = "a_wordle_secret"
@@ -124,6 +125,13 @@ def fetch_definition(word):
                     defs = meanings[0].get("definitions")
                     if defs:
                         return defs[0].get("definition")
+    except urllib.error.URLError:
+        try:
+            with open("offline_definitions.json") as f:
+                offline = json.load(f)
+            return offline.get(word)
+        except Exception:
+            pass
     except Exception:
         pass
     return None


### PR DESCRIPTION
## Summary
- hide close buttons on history/definition panels when on desktop
- provide fallback offline definitions if dictionary API can't be reached

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d84b1c58832fbbd909af258689cd