### PR TITLE
Use Firefox UA for dictionary lookup

### DIFF
--- a/server.py
+++ b/server.py
@@ -122,7 +122,16 @@ def fetch_definition(word):
     logging.info(f"Fetching definition for '{word}'")
     try:
         logging.info(f"Trying online dictionary API for '{word}'")
-        with urllib.request.urlopen(url, timeout=5) as resp:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) "
+                    "Gecko/20100101 Firefox/109.0"
+                )
+            },
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
             data = json.loads(resp.read().decode("utf-8"))
             if isinstance(data, list) and data:
                 meanings = data[0].get("meanings")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -394,6 +394,33 @@ def test_fetch_definition_exception(monkeypatch, server_env):
     assert definition is None
 
 
+def test_fetch_definition_sets_user_agent(monkeypatch, server_env):
+    server, _ = server_env
+
+    captured = {}
+
+    class DummyResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def read(self):
+            return b"[]"
+
+    def fake_urlopen(req, *a, **k):
+        ua = req.get_header('User-Agent') or req.get_header('User-agent')
+        captured['ua'] = ua
+        return DummyResp()
+
+    monkeypatch.setattr(server.urllib.request, 'urlopen', fake_urlopen)
+
+    server.fetch_definition('apple')
+
+    assert captured['ua'] and 'Mozilla' in captured['ua']
+
+
 def test_definition_available_after_game_over(monkeypatch, server_env):
     server, request = server_env
 


### PR DESCRIPTION
## Summary
- mimic Firefox when fetching definitions so API accepts requests
- verify the User-Agent header in a new test

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847077a6828832fb2ff584d168ac01f