### PR TITLE
Refine side panels and gear placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,9 @@
       padding: 5px;
       color: var(--text-color-light);
       line-height: 1;
-      margin-left: 10px;
+      position: absolute;
+      top: 0;
+      left: calc(100% + 10px);
     }
 
     #optionsMenu {
@@ -191,12 +193,18 @@
         right: auto;
         left: calc(100% + 20px);
       }
+      #historyBox {
+        transform-origin: right center;
+      }
+      #definitionBox {
+        transform-origin: left center;
+      }
       body:not(.history-open) #historyBox {
-        transform: translateX(100%);
+        transform: scale(0);
         opacity: 0;
       }
       body:not(.definition-open) #definitionBox {
-        transform: translateX(-100%);
+        transform: scale(0);
         opacity: 0;
       }
     }
@@ -902,12 +910,12 @@
         </button>
       </div>
       <h1>WordleWithFriends</h1>
-      <button id="optionsToggle" title="More Options">⚙️</button>
     </div>
 
     <!-- Board -->
     <div id="boardArea">
       <div id="board"></div>
+      <button id="optionsToggle" title="More Options">⚙️</button>
     </div>
 
     <!-- Guess Input -->


### PR DESCRIPTION
## Summary
- animate history and definition panels using scale
- keep panels near the board and remove slide translation
- move gear icon next to the board and position it absolutely

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684825610630832f8eeddb2b60dcbd1c