### PR TITLE
Improve neumorphic animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,6 +453,7 @@
       box-shadow: 4px 4px 8px var(--shadow-color-dark),
                   -4px -4px 8px var(--shadow-color-light);
       z-index: 100;
+      pointer-events: none;
     }
 
     /* ─── Keyboard ─── */
@@ -528,6 +529,14 @@
       50% { transform: translateX(6px); }
     }
 
+    /* ─── Fade In/Out Animation ─── */
+    @keyframes fadeInOut {
+      0% { opacity: 0; transform: translateY(-10px); }
+      10% { opacity: 1; transform: translateY(0); }
+      90% { opacity: 1; transform: translateY(0); }
+      100% { opacity: 0; transform: translateY(-10px); }
+    }
+
     /* ─── Hold-to-Reset Neumorphic ─── */
     #resetWrapper {
       display: inline-block;
@@ -546,7 +555,7 @@
       color: var(--text-color);
       box-shadow: 5px 5px 14px var(--shadow-color-dark),
                   -5px -5px 14px var(--shadow-color-light);
-      transition: box-shadow 0.2s, background 0.2s, color 0.2s;
+      transition: box-shadow 0.2s, background 0.2s, color 0.2s, transform 0.2s;
       cursor: pointer;
       outline: none;
       position: relative;
@@ -559,6 +568,7 @@
       box-shadow: inset 3px 3px 7px var(--inset-shadow-dark),
                   inset -3px -3px 7px var(--inset-shadow-light);
       color: var(--text-color-light);
+      transform: scale(0.95);
     }
 
     #holdResetProgress {

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,10 +4,23 @@ export function showMessage(msg, {messageEl, messagePopup}) {
   if (isMobile) {
     messagePopup.textContent = msg;
     messagePopup.style.display = 'block';
-    setTimeout(() => { messagePopup.style.display = 'none'; }, 2000);
+    messagePopup.style.animation = 'fadeInOut 2s';
+    messagePopup.addEventListener('animationend', () => {
+      messagePopup.style.display = 'none';
+      messagePopup.style.animation = '';
+    }, { once: true });
   } else {
     messageEl.textContent = msg;
-    messageEl.style.visibility = msg ? 'visible' : 'hidden';
+    if (msg) {
+      messageEl.style.visibility = 'visible';
+      messageEl.style.animation = 'fadeInOut 2s';
+      messageEl.addEventListener('animationend', () => {
+        messageEl.style.visibility = 'hidden';
+        messageEl.style.animation = '';
+      }, { once: true });
+    } else {
+      messageEl.style.visibility = 'hidden';
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add a generic fadeInOut keyframe animation
- animate message popups and desktop messages using fadeInOut
- make reset button press animation scale down
- prevent pointer events on message popup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684960f43824832fa2bf17ca02fe2c9b