### PR TITLE
Implement close call feature

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -273,7 +273,14 @@ async function submitGuessHandler() {
       definitionText.textContent = `${resp.state.target_word.toUpperCase()} – ${resp.state.definition}`;
     }
   } else {
-    showMessage(resp.msg, { messageEl, messagePopup });
+    if (resp.close_call) {
+      showMessage(
+        `Close call! ${resp.close_call.winner} beat you by ${resp.close_call.delta_ms}ms.`,
+        { messageEl, messagePopup }
+      );
+    } else {
+      showMessage(resp.msg, { messageEl, messagePopup });
+    }
     shakeInput(guessInput);
   }
 }


### PR DESCRIPTION
## Summary
- track timestamp of winning guess and save it
- expose close call info when a second player guesses within 1 second
- show close call notification in the frontend
- test close call scenarios

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684968d349b0832fbd5cf3c277200e9f