### PR TITLE
Responsive popup mode for side panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,29 @@
         transform: scale(0);
         opacity: 0;
       }
+
+      body.popup-mode #historyClose,
+      body.popup-mode #definitionClose {
+        display: block;
+      }
+      body.popup-mode #historyBox,
+      body.popup-mode #definitionBox {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        right: auto;
+        transform: translate(-50%, -50%) scale(0);
+        max-width: 90%;
+        z-index: 80;
+      }
+      body.popup-mode.history-open #historyBox {
+        transform: translate(-50%, -50%) scale(1);
+        opacity: 1;
+      }
+      body.popup-mode.definition-open #definitionBox {
+        transform: translate(-50%, -50%) scale(1);
+        opacity: 1;
+      }
     }
 
     h1 {
@@ -327,6 +350,27 @@
       margin: 20px auto;
       width: max-content;
       position: relative;
+    }
+
+    #stampContainer {
+      position: absolute;
+      top: 0;
+      left: 0;
+      pointer-events: none;
+      z-index: 5;
+      display: none;
+    }
+
+    .board-stamp {
+      position: absolute;
+      left: 0;
+      transform: translate(-110%, -50%);
+      font-size: 32px;
+      line-height: 1;
+    }
+
+    body.popup-mode #stampContainer {
+      display: block;
     }
 
     .tile {
@@ -923,6 +967,7 @@
     <!-- Board -->
     <div id="boardArea">
       <div id="board"></div>
+      <div id="stampContainer"></div>
       <button id="optionsToggle" title="More Options">⚙️</button>
     </div>
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,6 +75,25 @@ export function positionSidePanels(boardArea, historyBox, definitionBox) {
   }
 }
 
+export function updatePopupMode(boardArea, historyBox, definitionBox) {
+  if (window.innerWidth > 600) {
+    const total =
+      historyBox.offsetWidth +
+      boardArea.offsetWidth +
+      definitionBox.offsetWidth +
+      120; // margins used in positioning
+    if (total > window.innerWidth) {
+      document.body.classList.add('popup-mode');
+      document.body.classList.remove('history-open');
+      document.body.classList.remove('definition-open');
+    } else {
+      document.body.classList.remove('popup-mode');
+    }
+  } else {
+    document.body.classList.remove('popup-mode');
+  }
+}
+
 export function updateVH() {
   const vh = window.innerHeight * 0.01;
   document.documentElement.style.setProperty('--vh', `${vh}px`);


### PR DESCRIPTION
## Summary
- add popup-mode detection and layout in `utils.js`
- update board initialization to check panel fit in `main.js`
- make history/definition panels appear centered as popups on narrow desktop widths
- display emoji stamps beside board rows while in popup mode

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68498b097a6c832fb689809f68078ad2