### PR TITLE
Open panels when leaving popup mode

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -76,6 +76,7 @@ export function positionSidePanels(boardArea, historyBox, definitionBox) {
 }
 
 export function updatePopupMode(boardArea, historyBox, definitionBox) {
+  const wasPopup = document.body.classList.contains('popup-mode');
   if (window.innerWidth > 600) {
     const total =
       historyBox.offsetWidth +
@@ -91,6 +92,11 @@ export function updatePopupMode(boardArea, historyBox, definitionBox) {
     }
   } else {
     document.body.classList.remove('popup-mode');
+  }
+  const isPopup = document.body.classList.contains('popup-mode');
+  if (wasPopup && !isPopup && window.innerWidth > 600) {
+    document.body.classList.add('history-open');
+    document.body.classList.add('definition-open');
   }
 }
 


### PR DESCRIPTION
## Summary
- keep track of popup-mode changes
- automatically open history and definition panels when resizing from popup to desktop mode

## Testing
- `python -m pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6849904eec14832fbe7b4ea7a34d53c1