### PR TITLE
Fix popup panel positioning

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -98,6 +98,11 @@ export function updatePopupMode(boardArea, historyBox, definitionBox) {
     document.body.classList.add('history-open');
     document.body.classList.add('definition-open');
   }
+  // When switching to narrow screens, reset inline styles set by
+  // positionSidePanels so panels return to the normal flow.
+  if (window.innerWidth <= 600) {
+    positionSidePanels(boardArea, historyBox, definitionBox);
+  }
 }
 
 export function updateVH() {


### PR DESCRIPTION
## Summary
- reset side panel inline styles when switching to narrow viewports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a15aa710832f8b6dec902c9c1805