### PR TITLE
Fix popup panels in popup mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,6 +228,13 @@
         transform: translate(-50%, -50%) scale(1);
         opacity: 1;
       }
+      body.popup-mode #optionsMenu {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        max-width: 90%;
+      }
     }
 
     h1 {

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ let requiredLetters = new Set();
 let greenPositions = {};
 let gameOver = false;
 let latestState = null;
+let autoDefTimeout = null;
 
 const board = document.getElementById('board');
 const guessInput = document.getElementById('guessInput');
@@ -234,7 +235,7 @@ async function fetchState() {
     const constraints = updateHardModeConstraints(state.guesses);
     requiredLetters = constraints.requiredLetters;
     greenPositions = constraints.greenPositions;
-
+    const prevGameOver = gameOver;
     gameOver = state.is_over;
     guessInput.disabled = gameOver;
     submitButton.disabled = gameOver;
@@ -246,6 +247,15 @@ async function fetchState() {
       definitionText.textContent = `${state.last_word.toUpperCase()} – ${state.last_definition}`;
     } else {
       definitionText.textContent = '';
+    }
+
+    const justEnded = !prevGameOver && state.is_over;
+    if (justEnded && document.body.classList.contains('popup-mode')) {
+      document.body.classList.add('definition-open');
+      clearTimeout(autoDefTimeout);
+      autoDefTimeout = setTimeout(() => {
+        document.body.classList.remove('definition-open');
+      }, 10000);
     }
 
     const haveMy = activeEmojis.includes(myEmoji);
@@ -345,10 +355,19 @@ historyClose.addEventListener('click', () => { document.body.classList.remove('h
 definitionToggle.addEventListener('click', () => { document.body.classList.toggle('definition-open'); });
 definitionClose.addEventListener('click', () => { document.body.classList.remove('definition-open'); });
 optionsToggle.addEventListener('click', () => {
-  const rect = optionsToggle.getBoundingClientRect();
   optionsMenu.style.display = 'block';
-  optionsMenu.style.top = `${rect.bottom + window.scrollY}px`;
-  optionsMenu.style.left = `${rect.left + window.scrollX}px`;
+  if (document.body.classList.contains('popup-mode')) {
+    optionsMenu.style.position = 'fixed';
+    optionsMenu.style.top = '50%';
+    optionsMenu.style.left = '50%';
+    optionsMenu.style.transform = 'translate(-50%, -50%)';
+  } else {
+    const rect = optionsToggle.getBoundingClientRect();
+    optionsMenu.style.position = 'absolute';
+    optionsMenu.style.top = `${rect.bottom + window.scrollY}px`;
+    optionsMenu.style.left = `${rect.left + window.scrollX}px`;
+    optionsMenu.style.transform = '';
+  }
 });
 optionsClose.addEventListener('click', () => { optionsMenu.style.display = 'none'; });
 menuHistory.addEventListener('click', () => { historyToggle.click(); optionsMenu.style.display = 'none'; });

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,10 +98,15 @@ export function updatePopupMode(boardArea, historyBox, definitionBox) {
     document.body.classList.add('history-open');
     document.body.classList.add('definition-open');
   }
-  // When switching to narrow screens, reset inline styles set by
-  // positionSidePanels so panels return to the normal flow.
-  if (window.innerWidth <= 600) {
-    positionSidePanels(boardArea, historyBox, definitionBox);
+  // When switching to narrow screens or into popup mode, reset inline styles
+  // so panels are positioned by CSS rules instead of leftover absolute values.
+  if (window.innerWidth <= 600 || isPopup) {
+    historyBox.style.position = '';
+    historyBox.style.top = '';
+    historyBox.style.left = '';
+    definitionBox.style.position = '';
+    definitionBox.style.top = '';
+    definitionBox.style.left = '';
   }
 }
 

--- a/tests/test_popup_mode.py
+++ b/tests/test_popup_mode.py
@@ -29,8 +29,43 @@ import('./src/utils.js').then(({positionSidePanels, updatePopupMode}) => {
 });
 """)
 
+NODE_SCRIPT_WIDE = textwrap.dedent("""
+class ClassList {
+  constructor(){ this.set = new Set(); }
+  add(c){ this.set.add(c); }
+  remove(c){ this.set.delete(c); }
+  contains(c){ return this.set.has(c); }
+}
+
+global.document = {body:{classList:new ClassList()}, documentElement:{style:{setProperty(){}}}};
+global.window = {innerWidth:800, scrollX:0, scrollY:0};
+
+import('./src/utils.js').then(({positionSidePanels, updatePopupMode}) => {
+  const boardArea = {offsetWidth:300, getBoundingClientRect(){return {top:100, left:200, right:500}}};
+  const historyBox = {offsetWidth:100, style:{}};
+  const definitionBox = {offsetWidth:100, style:{}};
+  positionSidePanels(boardArea, historyBox, definitionBox);
+  window.innerWidth = 610;
+  updatePopupMode(boardArea, historyBox, definitionBox);
+  console.log(JSON.stringify({
+    historyTop: historyBox.style.top,
+    historyLeft: historyBox.style.left,
+    defTop: definitionBox.style.top,
+    defLeft: definitionBox.style.left
+  }));
+});
+""")
+
 def test_popup_mode_resets_inline_styles():
     result = subprocess.run(['node', '-e', NODE_SCRIPT], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['historyTop'] == ''
+    assert data['historyLeft'] == ''
+    assert data['defTop'] == ''
+    assert data['defLeft'] == ''
+
+def test_popup_mode_resets_styles_when_wide():
+    result = subprocess.run(['node', '-e', NODE_SCRIPT_WIDE], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
     assert data['historyTop'] == ''
     assert data['historyLeft'] == ''


### PR DESCRIPTION
## Summary
- clean up inline styles when entering popup mode
- allow options menu to open centered when in popup mode
- automatically show definition panel for 10 seconds after game ends in popup mode
- update styles so options menu centers over the board
- test popup mode style reset when switching while wide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849aa0fdf48832fb78b56350b08c7ba