### PR TITLE
Rename popup mode to overlay mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,12 +206,12 @@
         opacity: 0;
       }
 
-      body.popup-mode #historyClose,
-      body.popup-mode #definitionClose {
+      body.overlay-mode #historyClose,
+      body.overlay-mode #definitionClose {
         display: block;
       }
-      body.popup-mode #historyBox,
-      body.popup-mode #definitionBox {
+      body.overlay-mode #historyBox,
+      body.overlay-mode #definitionBox {
         position: fixed;
         top: 50%;
         left: 50%;
@@ -220,19 +220,15 @@
         max-width: 90%;
         z-index: 80;
       }
-      body.popup-mode.history-open #historyBox {
+      body.overlay-mode.history-open #historyBox {
         transform: translate(-50%, -50%) scale(1);
         opacity: 1;
       }
-      body.popup-mode.definition-open #definitionBox {
+      body.overlay-mode.definition-open #definitionBox {
         transform: translate(-50%, -50%) scale(1);
         opacity: 1;
       }
-      body.popup-mode #optionsMenu {
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
+      body.overlay-mode #optionsMenu {
         max-width: 90%;
       }
     }
@@ -376,7 +372,7 @@
       line-height: 1;
     }
 
-    body.popup-mode #stampContainer {
+    body.overlay-mode #stampContainer {
       display: block;
     }
 
@@ -700,6 +696,33 @@
       text-align: center;
     }
 
+    #closeCallPopup {
+      background: rgba(0, 0, 0, 0.33);
+      position: fixed;
+      z-index: 101;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    #closeCallBox {
+      background: var(--bg-color);
+      box-shadow: 0 8px 32px var(--shadow-color-dark),
+                  0 0 0 3px var(--shadow-color-light);
+      border-radius: 12px;
+      padding: 20px;
+      text-align: center;
+    }
+
+    #closeCallBox button {
+      margin-top: 12px;
+      font-size: 16px;
+    }
+
     .emoji-choice {
       font-size: 2.1em;
       margin: 12px;
@@ -933,6 +956,14 @@
         </div>
         <div id="emojiChoices"></div>
         <div id="emojiModalError" style="color: #ba1c1c; font-size:1em; margin-top:6px;"></div>
+      </div>
+    </div>
+
+    <!-- Close Call Popup -->
+    <div id="closeCallPopup" style="display:none;">
+      <div id="closeCallBox">
+        <div id="closeCallText"></div>
+        <button id="closeCallOk">OK</button>
       </div>
     </div>
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,8 +75,8 @@ export function positionSidePanels(boardArea, historyBox, definitionBox) {
   }
 }
 
-export function updatePopupMode(boardArea, historyBox, definitionBox) {
-  const wasPopup = document.body.classList.contains('popup-mode');
+export function updateOverlayMode(boardArea, historyBox, definitionBox) {
+  const wasPopup = document.body.classList.contains('overlay-mode');
   if (window.innerWidth > 600) {
     const total =
       historyBox.offsetWidth +
@@ -84,21 +84,21 @@ export function updatePopupMode(boardArea, historyBox, definitionBox) {
       definitionBox.offsetWidth +
       120; // margins used in positioning
     if (total > window.innerWidth) {
-      document.body.classList.add('popup-mode');
+      document.body.classList.add('overlay-mode');
       document.body.classList.remove('history-open');
       document.body.classList.remove('definition-open');
     } else {
-      document.body.classList.remove('popup-mode');
+      document.body.classList.remove('overlay-mode');
     }
   } else {
-    document.body.classList.remove('popup-mode');
+    document.body.classList.remove('overlay-mode');
   }
-  const isPopup = document.body.classList.contains('popup-mode');
+  const isPopup = document.body.classList.contains('overlay-mode');
   if (wasPopup && !isPopup && window.innerWidth > 600) {
     document.body.classList.add('history-open');
     document.body.classList.add('definition-open');
   }
-  // When switching to narrow screens or into popup mode, reset inline styles
+  // When switching to narrow screens or into overlay mode, reset inline styles
   // so panels are positioned by CSS rules instead of leftover absolute values.
   if (window.innerWidth <= 600 || isPopup) {
     historyBox.style.position = '';

--- a/tests/test_overlay_mode.py
+++ b/tests/test_overlay_mode.py
@@ -13,13 +13,13 @@ class ClassList {
 global.document = {body:{classList:new ClassList()}, documentElement:{style:{setProperty(){}}}};
 global.window = {innerWidth:800, scrollX:0, scrollY:0};
 
-import('./src/utils.js').then(({positionSidePanels, updatePopupMode}) => {
+import('./src/utils.js').then(({positionSidePanels, updateOverlayMode}) => {
   const boardArea = {offsetWidth:300, getBoundingClientRect(){return {top:100, left:200, right:500}}};
   const historyBox = {offsetWidth:100, style:{}};
   const definitionBox = {offsetWidth:100, style:{}};
   positionSidePanels(boardArea, historyBox, definitionBox);
   window.innerWidth = 500;
-  updatePopupMode(boardArea, historyBox, definitionBox);
+  updateOverlayMode(boardArea, historyBox, definitionBox);
   console.log(JSON.stringify({
     historyTop: historyBox.style.top,
     historyLeft: historyBox.style.left,
@@ -40,13 +40,13 @@ class ClassList {
 global.document = {body:{classList:new ClassList()}, documentElement:{style:{setProperty(){}}}};
 global.window = {innerWidth:800, scrollX:0, scrollY:0};
 
-import('./src/utils.js').then(({positionSidePanels, updatePopupMode}) => {
+import('./src/utils.js').then(({positionSidePanels, updateOverlayMode}) => {
   const boardArea = {offsetWidth:300, getBoundingClientRect(){return {top:100, left:200, right:500}}};
   const historyBox = {offsetWidth:100, style:{}};
   const definitionBox = {offsetWidth:100, style:{}};
   positionSidePanels(boardArea, historyBox, definitionBox);
   window.innerWidth = 610;
-  updatePopupMode(boardArea, historyBox, definitionBox);
+  updateOverlayMode(boardArea, historyBox, definitionBox);
   console.log(JSON.stringify({
     historyTop: historyBox.style.top,
     historyLeft: historyBox.style.left,
@@ -56,7 +56,7 @@ import('./src/utils.js').then(({positionSidePanels, updatePopupMode}) => {
 });
 """)
 
-def test_popup_mode_resets_inline_styles():
+def test_overlay_mode_resets_inline_styles():
     result = subprocess.run(['node', '-e', NODE_SCRIPT], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
     assert data['historyTop'] == ''
@@ -64,7 +64,7 @@ def test_popup_mode_resets_inline_styles():
     assert data['defTop'] == ''
     assert data['defLeft'] == ''
 
-def test_popup_mode_resets_styles_when_wide():
+def test_overlay_mode_resets_styles_when_wide():
     result = subprocess.run(['node', '-e', NODE_SCRIPT_WIDE], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
     assert data['historyTop'] == ''


### PR DESCRIPTION
## Summary
- rename popup-mode to overlay-mode across codebase
- show close-call messages in a dismissible popup
- reposition the options menu relative to the gear icon

## Testing
- `python -m pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6849c2acdd04832fa9970dbd05105eae