### PR TITLE
Fix side panel shrink animation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -105,27 +105,31 @@ export function positionSidePanels(boardArea, historyBox, definitionBox) {
 
 export function updateOverlayMode(boardArea, historyBox, definitionBox) {
   const wasPopup = document.body.classList.contains('overlay-mode');
+  let willBePopup = false;
   if (window.innerWidth > 600) {
     const total =
       historyBox.offsetWidth +
       boardArea.offsetWidth +
       definitionBox.offsetWidth +
       120; // margins used in positioning
-    if (total > window.innerWidth) {
-      document.body.classList.add('overlay-mode');
-      document.body.classList.remove('history-open');
-      document.body.classList.remove('definition-open');
-    } else {
-      document.body.classList.remove('overlay-mode');
-    }
-  } else {
-    document.body.classList.remove('overlay-mode');
+    willBePopup = total > window.innerWidth;
   }
-  const isPopup = document.body.classList.contains('overlay-mode');
-  if (!wasPopup && isPopup) {
+
+  if (!wasPopup && willBePopup) {
     animatePanelToCenter(historyBox);
     animatePanelToCenter(definitionBox);
   }
+
+  if (willBePopup) {
+    document.body.classList.add('overlay-mode');
+    document.body.classList.remove('history-open');
+    document.body.classList.remove('definition-open');
+  } else {
+    document.body.classList.remove('overlay-mode');
+  }
+
+  const isPopup = document.body.classList.contains('overlay-mode');
+
   if (wasPopup && !isPopup && window.innerWidth > 600) {
     document.body.classList.add('history-open');
     document.body.classList.add('definition-open');


### PR DESCRIPTION
## Summary
- ensure panel animation uses pre-resize position when switching to overlay mode

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e3f6bb7c832f81500d71564883e2