### PR TITLE
Update docs and add sanitize_definition test

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A small multiplayer adaptation of Wordle. The frontend lives in `index.html` whi
 - **Hold‑to‑reset button** (or instant reset once the game is over).
 - **Inactive player detection** – entries on the leaderboard fade if a player has not
   acted for several minutes.
+- **"Close call" notification** if another player submits the winning word less than a
+  second before you.
 
 ## Requirements
 
@@ -41,6 +43,9 @@ python server.py
 The server loads its words from `sgb-words.txt` and stores state in
 `game_persist.json`. It listens on port `5001`, so open
 `http://localhost:5001` in your browser to start playing.
+The API attempts to fetch word definitions from dictionaryapi.dev. If that fails
+or the network is unavailable, definitions are loaded from
+`offline_definitions.json`.
 
 ## Point System
 
@@ -56,12 +61,15 @@ first to uncover information about the hidden word:
 
 ## Testing
 
-Run the unit tests from the repository root. Make sure Pytest is installed
-(``pip install pytest`` if needed) and then run:
+Run the unit tests from the repository root. Make sure Pytest and Node.js are
+installed (`pip install pytest` and `node --version` should succeed) and then
+run:
 
 ```bash
 python -m pytest -v
 ```
+Some frontend tests execute small Node.js scripts, so a recent Node installation
+is required for the full suite to run successfully.
 
 ## Repository layout
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -413,6 +413,13 @@ def test_fetch_definition_strips_html(monkeypatch, server_env):
     assert definition == 'a fruit'
 
 
+def test_sanitize_definition_cleans_text(server_env):
+    server, _ = server_env
+    raw = '  <b>Fruit&nbsp;</b>   of <i>the</i>  tree  '
+    cleaned = server.sanitize_definition(raw)
+    assert cleaned == 'Fruit of the tree'
+
+
 def test_fetch_definition_exception(monkeypatch, server_env):
     server, _ = server_env
 


### PR DESCRIPTION
## Summary
- document close-call popup and dictionary fallback
- clarify test requirements and add Node.js note
- add unit test covering `sanitize_definition`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e879d8f4832f86c9751d7dd8f029