### PR TITLE
Enable ESM for node tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
- add a minimal `package.json` so Node treats `.js` as ES modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ebf123e4832f820bf6c9650f1fe1