### PR TITLE
Fix overlay mode tests for environments without navigator

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,6 @@
-export const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+export const isMobile =
+  typeof navigator !== 'undefined' &&
+  /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
 export function showMessage(msg, {messageEl, messagePopup}) {
   if (isMobile) {


### PR DESCRIPTION
## Summary
- guard `navigator` access in `src/utils.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849eeefc898832f8509e1a2e67b32c1