### PR TITLE
Implement chat box feature

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -85,3 +85,13 @@ overview and should be kept up to date as features evolve.
 - Potential future features include animations, sound effects, user account
   linking, hints, and internationalization support.
 
+## 7. Chat Box
+
+- Optional side panel for real-time text chat during a game.
+- Users can toggle the chat panel to show or hide it at any time.
+- The panel scales smoothly with all screen sizes, maintaining usability on mobile and desktop.
+- Uses each player's selected emoji as their chat avatar.
+- Messages appear with soft neumorphic bubbles and animated transitions.
+- Chat history updates live for all participants as messages are posted.
+- Must be fully keyboard accessible and responsive on mobile and desktop.
+

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,13 @@ as they are completed.
 - [ ] Provide hint or challenge modes.
 - [ ] Begin planning for internationalization support.
 
+## Chat Box
+
+- [x] Implement a chat panel for players to send messages during a game.
+- [x] Add a toggle control to show or hide the chat panel on any screen size.
+- [x] Use each player's selected emoji as their chat avatar.
+- [x] Add neumorphic animations for message bubbles appearing and disappearing.
+
 ## Code Quality
 
 - [ ] Expand unit tests to cover additional API and UI logic.

--- a/index.html
+++ b/index.html
@@ -207,11 +207,13 @@
       }
 
       body.overlay-mode #historyClose,
-      body.overlay-mode #definitionClose {
+      body.overlay-mode #definitionClose,
+      body.overlay-mode #chatClose {
         display: block;
       }
       body.overlay-mode #historyBox,
-      body.overlay-mode #definitionBox {
+      body.overlay-mode #definitionBox,
+      body.overlay-mode #chatBox {
         position: fixed;
         top: 50%;
         left: 50%;
@@ -225,6 +227,10 @@
         opacity: 1;
       }
       body.overlay-mode.definition-open #definitionBox {
+        transform: translate(-50%, -50%) scale(1);
+        opacity: 1;
+      }
+      body.overlay-mode.chat-open #chatBox {
         transform: translate(-50%, -50%) scale(1);
         opacity: 1;
       }
@@ -293,6 +299,46 @@
     }
     #definitionBox::-webkit-scrollbar {
       display: none;
+    }
+
+    #chatBox {
+      position: absolute;
+      top: 100px;
+      right: calc(20px + 280px);
+      width: 260px;
+      max-height: 70vh;
+      overflow-y: auto;
+      background: var(--bg-color);
+      padding: 10px;
+      border-radius: 8px;
+      box-shadow:
+        inset 2px 2px 5px var(--shadow-color-dark),
+        inset -2px -2px 5px var(--shadow-color-light);
+      transition: transform 0.3s ease, opacity 0.3s ease;
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+    }
+    #chatBox::-webkit-scrollbar { display: none; }
+
+    .chat-entry {
+      display: flex;
+      align-items: flex-start;
+      margin-bottom: 6px;
+      opacity: 0;
+      transform: translateY(10px);
+      transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+    .chat-entry.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    .chat-emoji { margin-right: 6px; }
+    .chat-bubble {
+      background: var(--bg-color);
+      padding: 6px 10px;
+      border-radius: 12px;
+      box-shadow: inset 2px 2px 5px var(--shadow-color-dark),
+                  inset -2px -2px 5px var(--shadow-color-light);
     }
 
     #historyList {
@@ -837,6 +883,23 @@
         z-index: 50;
       }
 
+      #chatBox {
+        display: none;
+        position: fixed;
+        bottom: 0;
+        right: 0;
+        width: 100%;
+        max-height: 0;
+        overflow-y: hidden;
+        border-radius: 0;
+        padding: 0;
+        box-shadow: none;
+        background: var(--bg-color);
+        opacity: 0;
+        transform: translateY(100%);
+        z-index: 50;
+      }
+
       body.history-open #historyBox {
         max-height: 50vh;
         max-width: calc(98% - 20px);
@@ -851,6 +914,20 @@
       }
 
       body.definition-open #definitionBox {
+        display: block;
+        max-height: 40vh;
+        max-width: calc(98% - 20px);
+        padding: 8px;
+        overflow-y: auto;
+        border-radius: 0;
+        box-shadow: inset 2px 2px 4px var(--shadow-color-dark),
+                    inset -2px -2px 4px var(--shadow-color-light);
+        opacity: 1;
+        transform: translateY(0);
+        transition: transform 0.3s ease, opacity 0.3s ease;
+      }
+
+      body.chat-open #chatBox {
         display: block;
         max-height: 40vh;
         max-width: calc(98% - 20px);
@@ -971,11 +1048,13 @@
     <!-- Option Buttons -->
     <button id="historyToggle" title="Show/Hide History">📜</button>
     <button id="definitionToggle" title="Show/Hide Definition">📖</button>
+    <button id="chatToggle" title="Show/Hide Chat">💬</button>
     <button id="darkModeToggle" title="Toggle Dark Mode">🌙</button>
     <div id="optionsMenu" style="display:none;">
       <button id="optionsClose" class="popup-close">✖</button>
       <button id="menuHistory">📜 History</button>
       <button id="menuDefinition">📖 Definition</button>
+      <button id="menuChat">💬 Chat</button>
       <button id="menuDarkMode">🌙/☀️</button>
     </div>
 
@@ -991,6 +1070,14 @@
     <div id="definitionBox">
       <button id="definitionClose" class="popup-close">✖</button>
       <div id="definitionText"></div>
+    </div>
+    <div id="chatBox">
+      <button id="chatClose" class="popup-close">✖</button>
+      <div id="chatMessages"></div>
+      <form id="chatForm" style="display:flex; margin-top:6px;">
+        <input id="chatInput" type="text" style="flex:1;" maxlength="140" autocomplete="off" />
+        <button id="chatSend" type="submit">Send</button>
+      </form>
     </div>
 
     <div id="titleBar">

--- a/src/api.js
+++ b/src/api.js
@@ -34,3 +34,18 @@ export async function sendHeartbeat(emoji) {
     body: JSON.stringify({ emoji })
   });
 }
+
+export async function sendChatMessage(text, emoji) {
+  const r = await fetch('/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text, emoji })
+  });
+  return r.json();
+}
+
+export async function getChatMessages() {
+  const r = await fetch('/chat');
+  if (!r.ok) throw new Error('Network response was not OK');
+  return r.json();
+}

--- a/src/chat.js
+++ b/src/chat.js
@@ -1,0 +1,16 @@
+export function renderChat(container, messages) {
+  container.innerHTML = '';
+  messages.forEach(m => {
+    const wrap = document.createElement('div');
+    wrap.className = 'chat-entry';
+    const emoji = document.createElement('span');
+    emoji.className = 'chat-emoji';
+    emoji.textContent = m.emoji;
+    const bubble = document.createElement('span');
+    bubble.className = 'chat-bubble';
+    bubble.textContent = m.text;
+    wrap.append(emoji, bubble);
+    container.appendChild(wrap);
+    requestAnimationFrame(() => wrap.classList.add('visible'));
+  });
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,7 +81,7 @@ function animatePanelToCenter(box) {
   }, 310);
 }
 
-export function positionSidePanels(boardArea, historyBox, definitionBox) {
+export function positionSidePanels(boardArea, historyBox, definitionBox, chatBox) {
   if (window.innerWidth > 600) {
     const boardRect = boardArea.getBoundingClientRect();
     const top = boardRect.top + window.scrollY;
@@ -95,6 +95,11 @@ export function positionSidePanels(boardArea, historyBox, definitionBox) {
     definitionBox.style.position = 'absolute';
     definitionBox.style.top = `${top}px`;
     definitionBox.style.left = `${right + 60}px`;
+    if (chatBox) {
+      chatBox.style.position = 'absolute';
+      chatBox.style.top = `${top}px`;
+      chatBox.style.left = `${right + definitionBox.offsetWidth + 100}px`;
+    }
   } else {
     historyBox.style.position = '';
     historyBox.style.top = '';
@@ -102,10 +107,15 @@ export function positionSidePanels(boardArea, historyBox, definitionBox) {
     definitionBox.style.position = '';
     definitionBox.style.top = '';
     definitionBox.style.left = '';
+    if (chatBox) {
+      chatBox.style.position = '';
+      chatBox.style.top = '';
+      chatBox.style.left = '';
+    }
   }
 }
 
-export function updateOverlayMode(boardArea, historyBox, definitionBox) {
+export function updateOverlayMode(boardArea, historyBox, definitionBox, chatBox) {
   const wasPopup = document.body.classList.contains('overlay-mode');
   let willBePopup = false;
   if (window.innerWidth > 600) {
@@ -113,6 +123,7 @@ export function updateOverlayMode(boardArea, historyBox, definitionBox) {
       historyBox.offsetWidth +
       boardArea.offsetWidth +
       definitionBox.offsetWidth +
+      (chatBox ? chatBox.offsetWidth : 0) +
       120; // margins used in positioning
     willBePopup = total > window.innerWidth;
   }
@@ -120,12 +131,14 @@ export function updateOverlayMode(boardArea, historyBox, definitionBox) {
   if (!wasPopup && willBePopup) {
     animatePanelToCenter(historyBox);
     animatePanelToCenter(definitionBox);
+    if (chatBox) animatePanelToCenter(chatBox);
   }
 
   if (willBePopup) {
     document.body.classList.add('overlay-mode');
     document.body.classList.remove('history-open');
     document.body.classList.remove('definition-open');
+    document.body.classList.remove('chat-open');
   } else {
     document.body.classList.remove('overlay-mode');
   }
@@ -135,6 +148,7 @@ export function updateOverlayMode(boardArea, historyBox, definitionBox) {
   if (wasPopup && !isPopup && window.innerWidth > 600) {
     document.body.classList.add('history-open');
     document.body.classList.add('definition-open');
+    if (chatBox) document.body.classList.add('chat-open');
   }
   // When switching to narrow screens or into overlay mode, reset inline styles
   // so panels are positioned by CSS rules instead of leftover absolute values.
@@ -147,6 +161,11 @@ export function updateOverlayMode(boardArea, historyBox, definitionBox) {
       definitionBox.style.position = '';
       definitionBox.style.top = '';
       definitionBox.style.left = '';
+      if (chatBox) {
+        chatBox.style.position = '';
+        chatBox.style.top = '';
+        chatBox.style.left = '';
+      }
     }
   }
 }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -615,3 +615,18 @@ def test_close_call_not_triggered(monkeypatch, server_env):
     assert status == 403
     assert 'close_call' not in data
 
+
+def test_chat_post_and_get(server_env):
+    server, request = server_env
+
+    request.method = 'POST'
+    request.json = {'text': 'hello', 'emoji': '😀'}
+    resp = server.chat()
+    assert resp['status'] == 'ok'
+    assert server.chat_messages[-1]['text'] == 'hello'
+
+    request.method = 'GET'
+    request.json = None
+    data = server.chat()
+    assert data['messages'][-1]['text'] == 'hello'
+


### PR DESCRIPTION
## Summary
- add chat side panel UI and controls
- update utilities and main script to handle chat box
- support chat endpoints in the Flask server
- provide API helpers and rendering for chat
- extend server tests for chat messaging
- check off chat feature TODO items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849fb5e6fa8832faba63302edfc211b