### PR TITLE
Fix chat panel refresh flashing and add neumorphic input styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,13 +333,45 @@
       transform: translateY(0);
     }
     .chat-emoji { margin-right: 6px; }
-    .chat-bubble {
-      background: var(--bg-color);
-      padding: 6px 10px;
-      border-radius: 12px;
-      box-shadow: inset 2px 2px 5px var(--shadow-color-dark),
-                  inset -2px -2px 5px var(--shadow-color-light);
-    }
+      .chat-bubble {
+        background: var(--bg-color);
+        padding: 6px 10px;
+        border-radius: 12px;
+        box-shadow: inset 2px 2px 5px var(--shadow-color-dark),
+                    inset -2px -2px 5px var(--shadow-color-light);
+      }
+
+      #chatInput,
+      #chatSend {
+        border: none;
+        padding: 8px 12px;
+        font-size: 16px;
+        border-radius: 10px;
+        background-color: var(--bg-color);
+        box-shadow: inset 3px 3px 6px var(--inset-shadow-dark),
+                    inset -3px -3px 6px var(--inset-shadow-light);
+        color: var(--text-color);
+        outline: none;
+        transition: box-shadow 0.2s, background-color 0.3s, color 0.3s;
+      }
+
+      #chatInput {
+        flex: 1;
+        margin-right: 6px;
+      }
+
+      #chatSend {
+        cursor: pointer;
+        font-weight: 500;
+        box-shadow: 5px 5px 10px var(--shadow-color-dark),
+                    -5px -5px 10px var(--shadow-color-light);
+      }
+
+      #chatSend:active {
+        box-shadow: inset 3px 3px 6px var(--inset-shadow-dark),
+                    inset -3px -3px 6px var(--inset-shadow-light);
+        color: var(--text-color-light);
+      }
 
     #historyList {
       list-style: none;

--- a/src/chat.js
+++ b/src/chat.js
@@ -1,6 +1,15 @@
 export function renderChat(container, messages) {
-  container.innerHTML = '';
-  messages.forEach(m => {
+  // If messages were cleared (e.g., new game), reset the container
+  if (messages.length < container.childElementCount) {
+    container.innerHTML = '';
+  }
+
+  const wasAtBottom =
+    Math.abs(container.scrollHeight - container.scrollTop - container.clientHeight) < 5;
+
+  // Append any new messages that haven't been rendered yet
+  for (let i = container.childElementCount; i < messages.length; i++) {
+    const m = messages[i];
     const wrap = document.createElement('div');
     wrap.className = 'chat-entry';
     const emoji = document.createElement('span');
@@ -12,5 +21,10 @@ export function renderChat(container, messages) {
     wrap.append(emoji, bubble);
     container.appendChild(wrap);
     requestAnimationFrame(() => wrap.classList.add('visible'));
-  });
+  }
+
+  // Keep the view pinned to the latest message if user was at bottom
+  if (messages.length && wasAtBottom) {
+    container.scrollTop = container.scrollHeight;
+  }
 }


### PR DESCRIPTION
## Summary
- style chat input and send button using neumorphic theme
- keep chat scroll position and only append new messages to prevent flashing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a2b90beb8832f817c9b5cdf3563f0