### PR TITLE
Fix chat layout positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,7 +304,7 @@
     #chatBox {
       position: absolute;
       top: 100px;
-      right: calc(20px + 280px);
+      left: calc(100% + 20px);
       width: 260px;
       max-height: 70vh;
       overflow-y: auto;
@@ -358,6 +358,7 @@
       #chatInput {
         flex: 1;
         margin-right: 6px;
+        min-width: 0;
       }
 
       #chatSend {
@@ -1104,7 +1105,7 @@
       <div id="definitionText"></div>
     </div>
     <div id="chatBox">
-      <button id="chatClose" class="popup-close">✖</button>
+      <button id="chatClose" class="popup-close" type="button">✖</button>
       <div id="chatMessages"></div>
       <form id="chatForm" style="display:flex; margin-top:6px;">
         <input id="chatInput" type="text" style="flex:1;" maxlength="140" autocomplete="off" />

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,8 +97,8 @@ export function positionSidePanels(boardArea, historyBox, definitionBox, chatBox
     definitionBox.style.left = `${right + 60}px`;
     if (chatBox) {
       chatBox.style.position = 'absolute';
-      chatBox.style.top = `${top}px`;
-      chatBox.style.left = `${right + definitionBox.offsetWidth + 100}px`;
+      chatBox.style.left = `${right + 60}px`;
+      chatBox.style.top = `${top + definitionBox.offsetHeight + 20}px`;
     }
   } else {
     historyBox.style.position = '';
@@ -123,7 +123,6 @@ export function updateOverlayMode(boardArea, historyBox, definitionBox, chatBox)
       historyBox.offsetWidth +
       boardArea.offsetWidth +
       definitionBox.offsetWidth +
-      (chatBox ? chatBox.offsetWidth : 0) +
       120; // margins used in positioning
     willBePopup = total > window.innerWidth;
   }


### PR DESCRIPTION
## Summary
- place chat panel below definition panel on wide screens
- prevent chat input overflow by allowing flex shrinking
- add button type to chat close button
- adjust overlay width calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3812d7dc832f9210f8115e37e915