### PR TITLE
Fix chat overlay initial position

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -407,6 +407,8 @@ renderEmojiStamps([]);
 if (window.innerWidth > 600 && !document.body.classList.contains('overlay-mode')) {
   document.body.classList.add('history-open');
   document.body.classList.add('definition-open');
+  // Recalculate panel positions now that definition is visible
+  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
 }
 fetchState();
 startPolling(FAST_INTERVAL);


### PR DESCRIPTION
## Summary
- ensure chat panel is positioned after definition panel becomes visible

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab249fe50832fb6cb95a0b7d91f22