### PR TITLE
Add board tile reset animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,6 +507,14 @@
                   inset -3px -3px 6px var(--absent-shadow-light);
     }
 
+    .tile.reset-out {
+      animation: tileResetOut 0.25s forwards;
+    }
+
+    .tile.reset-in {
+      animation: tileResetIn 0.25s forwards;
+    }
+
     /* ─── Input & Buttons ─── */
     #inputArea {
       display: flex;
@@ -661,6 +669,30 @@
       10% { opacity: 1; transform: translateY(0); }
       90% { opacity: 1; transform: translateY(0); }
       100% { opacity: 0; transform: translateY(-10px); }
+    }
+
+    @keyframes tileResetOut {
+      to {
+        box-shadow: 0 0 0 var(--shadow-color-dark),
+                    0 0 0 var(--shadow-color-light);
+        transform: scale(0.8);
+        opacity: 0;
+      }
+    }
+
+    @keyframes tileResetIn {
+      from {
+        box-shadow: 0 0 0 var(--shadow-color-dark),
+                    0 0 0 var(--shadow-color-light);
+        transform: scale(0.8);
+        opacity: 0;
+      }
+      to {
+        box-shadow: 5px 5px 10px var(--shadow-color-dark),
+                    -5px -5px 10px var(--shadow-color-light);
+        transform: scale(1);
+        opacity: 1;
+      }
     }
 
     /* ─── Hold-to-Reset Neumorphic ─── */

--- a/src/board.js
+++ b/src/board.js
@@ -29,6 +29,21 @@ export function updateBoard(board, state, guessInput, rows = 6, gameOver = false
   }
 }
 
+export function animateTilesOut(board) {
+  const tiles = Array.from(board.children);
+  tiles.forEach(t => t.classList.add('reset-out'));
+  return new Promise(resolve => setTimeout(resolve, 250));
+}
+
+export function animateTilesIn(board) {
+  const tiles = Array.from(board.children);
+  tiles.forEach(t => {
+    t.classList.add('reset-in');
+    t.addEventListener('animationend', () => t.classList.remove('reset-in'), { once: true });
+  });
+  return new Promise(resolve => setTimeout(resolve, 250));
+}
+
 export function resetKeyboard(keyboard) {
   Array.from(keyboard.querySelectorAll('.key')).forEach(key => {
     key.classList.remove('correct', 'present', 'absent');

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { createBoard, updateBoard, updateKeyboardFromGuesses, updateHardModeConstraints, isValidHardModeGuess } from './board.js';
+import { createBoard, updateBoard, updateKeyboardFromGuesses, updateHardModeConstraints, isValidHardModeGuess, animateTilesOut, animateTilesIn } from './board.js';
 import { renderHistory } from './history.js';
 import { getMyEmoji, setMyEmoji, showEmojiModal } from './emoji.js';
 import { getState, sendGuess, resetGame, sendHeartbeat, sendChatMessage } from './api.js';
@@ -160,6 +160,14 @@ function renderEmojiStamps(guesses) {
   });
 }
 
+async function performReset() {
+  await animateTilesOut(board);
+  await resetGame();
+  await fetchState();
+  await animateTilesIn(board);
+  showMessage('Game reset!', { messageEl, messagePopup });
+}
+
 function updateResetButton() {
   if (gameOver) {
     holdResetText.textContent = 'Reset';
@@ -167,12 +175,7 @@ function updateResetButton() {
     holdResetProgress.style.opacity = '0';
     holdReset.onmousedown = null;
     holdReset.ontouchstart = null;
-    holdReset.onclick = () => {
-      resetGame().then(() => {
-        fetchState();
-        showMessage('Game reset!', { messageEl, messagePopup });
-      });
-    };
+    holdReset.onclick = () => { performReset(); };
   } else {
     holdResetText.textContent = 'Reset';
     holdResetProgress.style.opacity = '0.9';
@@ -205,10 +208,7 @@ function startHoldReset() {
       setTimeout(() => {
         holdResetProgress.style.width = '0%';
       }, 350);
-      resetGame().then(() => {
-        fetchState();
-        showMessage('Game reset!', { messageEl, messagePopup });
-      });
+      performReset();
     }
   }, 20);
 }


### PR DESCRIPTION
## Summary
- animate tiles out/in during game reset for a smoother look
- expose `animateTilesOut` and `animateTilesIn` helpers
- use `performReset` in main logic
- add CSS keyframes for reset animations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684abdff3188832f8c3a243e4290277f