### PR TITLE
Remove chat toggle and fix chat typing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1113,7 +1113,6 @@
     <!-- Option Buttons -->
     <button id="historyToggle" title="Show/Hide History">📜</button>
     <button id="definitionToggle" title="Show/Hide Definition">📖</button>
-    <button id="chatToggle" title="Show/Hide Chat">💬</button>
     <button id="darkModeToggle" title="Toggle Dark Mode">🌙</button>
     <div id="optionsMenu" style="display:none;">
       <button id="optionsClose" class="popup-close">✖</button>

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -34,7 +34,12 @@ export function setupTypingListeners({keyboardEl, guessInput, submitButton, subm
       event.preventDefault();
       return;
     }
-    if (guessInput.disabled || document.activeElement === guessInput) return;
+    const active = document.activeElement;
+    if (guessInput.disabled || active === guessInput) return;
+    if (active && active !== document.body &&
+        (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
+      return;
+    }
     const key = event.key.toLowerCase();
     const currentValue = guessInput.value;
     if (key === 'enter') {

--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,6 @@ const historyToggle = document.getElementById('historyToggle');
 const definitionToggle = document.getElementById('definitionToggle');
 const definitionText = document.getElementById('definitionText');
 const definitionBox = document.getElementById('definitionBox');
-const chatToggle = document.getElementById('chatToggle');
 const chatBox = document.getElementById('chatBox');
 const chatMessagesEl = document.getElementById('chatMessages');
 const chatForm = document.getElementById('chatForm');
@@ -372,7 +371,6 @@ historyToggle.addEventListener('click', () => { document.body.classList.toggle('
 historyClose.addEventListener('click', () => { document.body.classList.remove('history-open'); });
 definitionToggle.addEventListener('click', () => { document.body.classList.toggle('definition-open'); });
 definitionClose.addEventListener('click', () => { document.body.classList.remove('definition-open'); });
-chatToggle.addEventListener('click', () => { document.body.classList.toggle('chat-open'); });
 chatClose.addEventListener('click', () => { document.body.classList.remove('chat-open'); });
 optionsToggle.addEventListener('click', () => {
   optionsMenu.style.display = 'block';
@@ -394,7 +392,10 @@ optionsToggle.addEventListener('click', () => {
 optionsClose.addEventListener('click', () => { optionsMenu.style.display = 'none'; });
 menuHistory.addEventListener('click', () => { historyToggle.click(); optionsMenu.style.display = 'none'; });
 menuDefinition.addEventListener('click', () => { definitionToggle.click(); optionsMenu.style.display = 'none'; });
-menuChat.addEventListener('click', () => { chatToggle.click(); optionsMenu.style.display = 'none'; });
+menuChat.addEventListener('click', () => {
+  document.body.classList.toggle('chat-open');
+  optionsMenu.style.display = 'none';
+});
 menuDarkMode.addEventListener('click', () => { darkModeToggle.click(); });
 closeCallOk.addEventListener('click', () => { closeCallPopup.style.display = 'none'; });
 


### PR DESCRIPTION
## Summary
- drop chat toggle button from header
- ignore global key handling when an input (like chat) is focused
- toggle chat from the options menu directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac91bf4f4832fa3abe12bdb9d1f97