### PR TITLE
Implement layout modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,13 @@ is required for the full suite to run successfully.
 - `index.html` – browser client
 - `sgb-words.txt` – word list used by the game
 - `tests/` – Pytest suite
+
+## Layout Modes
+
+The client adjusts its interface based on viewport width:
+
+- **Light Mode** – up to **600px** wide. The layout stacks vertically with large touch areas and panels sliding up from the bottom.
+- **Medium Mode** – widths between **601px** and **900px**. Panels sit beside the board but use narrower widths and slightly smaller tiles.
+- **Full Mode** – wider than **900px**. The game uses the largest tile and panel sizes and displays the richest interface.
+
+The mode updates automatically on window resize or device orientation changes.

--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
       max-height: 70vh;
       overflow-y: auto;
       background: var(--bg-color);
-      padding: 10px;
+      padding: 36px 10px 10px;
       border-radius: 8px;
       box-shadow:
         inset 2px 2px 5px var(--shadow-color-dark),
@@ -1012,7 +1012,7 @@
         display: block;
         max-height: 40vh;
         max-width: calc(98% - 20px);
-        padding: 8px;
+        padding: 36px 8px 8px;
         overflow-y: auto;
         border-radius: 0;
         box-shadow: inset 2px 2px 4px var(--shadow-color-dark),
@@ -1100,6 +1100,33 @@
       #message {
         font-size: 16px;
         margin-top: 12px;
+      }
+    }
+
+    /* ─────────────────────────────────────────────
+       C) Medium mode adjustments
+       ───────────────────────────────────────────── */
+    @media (min-width: 601px) and (max-width: 900px) {
+      #historyBox,
+      #definitionBox,
+      #chatBox {
+        width: 220px;
+      }
+
+      #board {
+        grid-template-columns: repeat(5, 55px);
+        grid-gap: 8px;
+        max-width: 307px;
+      }
+
+      .tile {
+        width: 55px;
+        height: 55px;
+      }
+
+      .key {
+        min-width: 34px;
+        height: 50px;
       }
     }
   </style>

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import { getMyEmoji, setMyEmoji, showEmojiModal } from './emoji.js';
 import { getState, sendGuess, resetGame, sendHeartbeat, sendChatMessage } from './api.js';
 import { renderChat } from './chat.js';
 import { setupTypingListeners, updateBoardFromTyping } from './keyboard.js';
-import { showMessage, applyDarkModePreference, shakeInput, repositionResetButton, positionSidePanels, updateOverlayMode, updateVH, isMobile } from './utils.js';
+import { showMessage, applyDarkModePreference, shakeInput, repositionResetButton, positionSidePanels, updateOverlayMode, updateVH, applyLayoutMode, isMobile } from './utils.js';
 
 let activeEmojis = [];
 let leaderboard = [];
@@ -369,11 +369,26 @@ darkModeToggle.addEventListener('click', () => {
   applyDarkModePreference(darkModeToggle);
 });
 
-historyToggle.addEventListener('click', () => { document.body.classList.toggle('history-open'); });
-historyClose.addEventListener('click', () => { document.body.classList.remove('history-open'); });
-definitionToggle.addEventListener('click', () => { document.body.classList.toggle('definition-open'); });
-definitionClose.addEventListener('click', () => { document.body.classList.remove('definition-open'); });
-chatClose.addEventListener('click', () => { document.body.classList.remove('chat-open'); });
+historyToggle.addEventListener('click', () => {
+  document.body.classList.toggle('history-open');
+  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
+});
+historyClose.addEventListener('click', () => {
+  document.body.classList.remove('history-open');
+  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
+});
+definitionToggle.addEventListener('click', () => {
+  document.body.classList.toggle('definition-open');
+  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
+});
+definitionClose.addEventListener('click', () => {
+  document.body.classList.remove('definition-open');
+  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
+});
+chatClose.addEventListener('click', () => {
+  document.body.classList.remove('chat-open');
+  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
+});
 optionsToggle.addEventListener('click', () => {
   optionsMenu.style.display = 'block';
   const rect = optionsToggle.getBoundingClientRect();
@@ -397,11 +412,13 @@ menuDefinition.addEventListener('click', () => { definitionToggle.click(); optio
 menuChat.addEventListener('click', () => {
   document.body.classList.toggle('chat-open');
   optionsMenu.style.display = 'none';
+  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
 });
 menuDarkMode.addEventListener('click', () => { darkModeToggle.click(); });
 closeCallOk.addEventListener('click', () => { closeCallPopup.style.display = 'none'; });
 
 applyDarkModePreference(darkModeToggle);
+applyLayoutMode();
 createBoard(board, maxRows);
 repositionResetButton();
 positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
@@ -422,6 +439,7 @@ window.addEventListener('resize', repositionResetButton);
 window.addEventListener('resize', () => {
   positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
   updateOverlayMode(boardArea, historyBox, definitionBoxEl, chatBox);
+  applyLayoutMode();
   if (latestState) renderEmojiStamps(latestState.guesses);
 });
 updateVH();

--- a/src/utils.js
+++ b/src/utils.js
@@ -173,3 +173,16 @@ export function updateVH() {
   const vh = window.innerHeight * 0.01;
   document.documentElement.style.setProperty('--vh', `${vh}px`);
 }
+
+export function applyLayoutMode() {
+  const width = window.innerWidth;
+  let mode = 'full';
+  if (width <= 600) {
+    mode = 'light';
+  } else if (width <= 900) {
+    mode = 'medium';
+  }
+  if (document.body.dataset.mode !== mode) {
+    document.body.dataset.mode = mode;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `applyLayoutMode` to detect light/medium/full screen sizes
- call new helper from the app to switch mode on resize
- add Medium mode CSS for tablet-sized screens
- document layout breakpoints in README
- reposition panels when opened and ensure chat input doesn't cover close button

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b177422f8832f85680222a0ebdf65