### PR TITLE
Update medium mode panel display

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,13 +173,14 @@
       align-items: center;
       justify-content: center;
       padding: 0;
+      z-index: 1000;
     }
     .close-btn:active {
       box-shadow: inset 2px 2px 4px var(--inset-shadow-dark),
                   inset -2px -2px 4px var(--inset-shadow-light);
     }
 
-    @media (min-width: 601px) {
+    @media (min-width: 901px) {
       #historyClose,
       #definitionClose {
         display: none;
@@ -1111,6 +1112,35 @@
       #definitionBox,
       #chatBox {
         width: 220px;
+      }
+
+      #optionsToggle {
+        display: block;
+      }
+
+      body[data-mode='medium'] #historyClose,
+      body[data-mode='medium'] #definitionClose,
+      body[data-mode='medium'] #chatClose {
+        display: block;
+      }
+
+      body[data-mode='medium'] #historyBox,
+      body[data-mode='medium'] #definitionBox,
+      body[data-mode='medium'] #chatBox {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        max-width: 90%;
+        max-height: 80vh;
+        overflow-y: auto;
+        z-index: 80;
+      }
+
+      body[data-mode='medium']:not(.history-open) #historyBox,
+      body[data-mode='medium']:not(.definition-open) #definitionBox,
+      body[data-mode='medium']:not(.chat-open) #chatBox {
+        display: none;
       }
 
       #board {

--- a/src/main.js
+++ b/src/main.js
@@ -354,6 +354,16 @@ function checkInactivity() {
   }
 }
 
+function togglePanel(panelClass) {
+  if (document.body.dataset.mode === 'medium') {
+    ['history-open', 'definition-open', 'chat-open'].forEach(c => {
+      if (c !== panelClass) document.body.classList.remove(c);
+    });
+  }
+  document.body.classList.toggle(panelClass);
+  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
+}
+
 setupTypingListeners({
   keyboardEl: keyboard,
   guessInput,
@@ -370,16 +380,14 @@ darkModeToggle.addEventListener('click', () => {
 });
 
 historyToggle.addEventListener('click', () => {
-  document.body.classList.toggle('history-open');
-  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
+  togglePanel('history-open');
 });
 historyClose.addEventListener('click', () => {
   document.body.classList.remove('history-open');
   positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
 });
 definitionToggle.addEventListener('click', () => {
-  document.body.classList.toggle('definition-open');
-  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
+  togglePanel('definition-open');
 });
 definitionClose.addEventListener('click', () => {
   document.body.classList.remove('definition-open');
@@ -410,9 +418,8 @@ optionsClose.addEventListener('click', () => { optionsMenu.style.display = 'none
 menuHistory.addEventListener('click', () => { historyToggle.click(); optionsMenu.style.display = 'none'; });
 menuDefinition.addEventListener('click', () => { definitionToggle.click(); optionsMenu.style.display = 'none'; });
 menuChat.addEventListener('click', () => {
-  document.body.classList.toggle('chat-open');
+  togglePanel('chat-open');
   optionsMenu.style.display = 'none';
-  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
 });
 menuDarkMode.addEventListener('click', () => { darkModeToggle.click(); });
 closeCallOk.addEventListener('click', () => { closeCallPopup.style.display = 'none'; });
@@ -424,7 +431,7 @@ repositionResetButton();
 positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
 updateOverlayMode(boardArea, historyBox, definitionBoxEl, chatBox);
 renderEmojiStamps([]);
-if (window.innerWidth > 600 && !document.body.classList.contains('overlay-mode')) {
+if (window.innerWidth > 900 && !document.body.classList.contains('overlay-mode')) {
   document.body.classList.add('history-open');
   document.body.classList.add('definition-open');
   // Recalculate panel positions now that definition is visible

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,7 +82,7 @@ function animatePanelToCenter(box) {
 }
 
 export function positionSidePanels(boardArea, historyBox, definitionBox, chatBox) {
-  if (window.innerWidth > 600) {
+  if (window.innerWidth > 900) {
     const boardRect = boardArea.getBoundingClientRect();
     const top = boardRect.top + window.scrollY;
     const left = boardRect.left + window.scrollX;
@@ -118,7 +118,7 @@ export function positionSidePanels(boardArea, historyBox, definitionBox, chatBox
 export function updateOverlayMode(boardArea, historyBox, definitionBox, chatBox) {
   const wasPopup = document.body.classList.contains('overlay-mode');
   let willBePopup = false;
-  if (window.innerWidth > 600) {
+  if (window.innerWidth > 900) {
     const total =
       historyBox.offsetWidth +
       boardArea.offsetWidth +
@@ -144,7 +144,7 @@ export function updateOverlayMode(boardArea, historyBox, definitionBox, chatBox)
 
   const isPopup = document.body.classList.contains('overlay-mode');
 
-  if (wasPopup && !isPopup && window.innerWidth > 600) {
+  if (wasPopup && !isPopup && window.innerWidth > 900) {
     document.body.classList.add('history-open');
     document.body.classList.add('definition-open');
     if (chatBox) document.body.classList.add('chat-open');


### PR DESCRIPTION
## Summary
- ensure close buttons stay above all content
- revise panel layout rules for medium screens
- open only one panel at a time in medium mode
- adjust JS to handle new panel logic
- tweak side panel calculations for large layouts only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b26474494832fa98f7b7849f2899b