### PR TITLE
Improve chat panel usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,7 +324,9 @@
       left: calc(100% + 20px);
       width: 260px;
       max-height: 70vh;
-      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
       background: var(--bg-color);
       padding: 36px 10px 10px;
       border-radius: 8px;
@@ -332,10 +334,31 @@
         inset 2px 2px 5px var(--shadow-color-dark),
         inset -2px -2px 5px var(--shadow-color-light);
       transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+
+    #chatMessages {
+      flex: 1 1 auto;
+      overflow-y: auto;
       scrollbar-width: none;
       -ms-overflow-style: none;
     }
-    #chatBox::-webkit-scrollbar { display: none; }
+    #chatMessages::-webkit-scrollbar { display: none; }
+
+    #chatForm {
+      display: flex;
+      margin-top: 6px;
+      position: sticky;
+      bottom: 0;
+      background: var(--bg-color);
+      padding-bottom: 4px;
+    }
+
+    #chatClose {
+      position: sticky;
+      top: 5px;
+      right: 5px;
+      align-self: flex-end;
+    }
 
     .chat-entry {
       display: flex;
@@ -972,7 +995,7 @@
         right: 0;
         width: 100%;
         max-height: 0;
-        overflow-y: hidden;
+        overflow: hidden;
         border-radius: 0;
         padding: 0;
         box-shadow: none;
@@ -980,6 +1003,8 @@
         opacity: 0;
         transform: translateY(100%);
         z-index: 50;
+        display: flex;
+        flex-direction: column;
       }
 
       body.history-open #historyBox {
@@ -1010,17 +1035,18 @@
       }
 
       body.chat-open #chatBox {
-        display: block;
+        display: flex;
         max-height: 40vh;
         max-width: calc(98% - 20px);
         padding: 36px 8px 8px;
-        overflow-y: auto;
+        overflow: hidden;
         border-radius: 0;
         box-shadow: inset 2px 2px 4px var(--shadow-color-dark),
                     inset -2px -2px 4px var(--shadow-color-light);
         opacity: 1;
         transform: translateY(0);
         transition: transform 0.3s ease, opacity 0.3s ease;
+        flex-direction: column;
       }
 
       #historyBox h3 {
@@ -1135,6 +1161,12 @@
         max-height: 80vh;
         overflow-y: auto;
         z-index: 80;
+      }
+
+      body[data-mode='medium'] #chatBox {
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
       }
 
       body[data-mode='medium']:not(.history-open) #historyBox,


### PR DESCRIPTION
## Summary
- keep chat input and close button visible while scrolling messages
- adjust styles for mobile and medium layouts so chat panel uses flexbox

## Testing
- `python -m pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_684b31b846d8832fb04017bc7c2d79c9