### PR TITLE
Remove redundant option buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,46 +80,6 @@
       overflow-y: auto;
     }
 
-    #darkModeToggle {
-      position: absolute;
-      top: 15px;
-      right: 15px;
-      font-size: 24px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      padding: 5px;
-      color: var(--text-color-light);
-      line-height: 1;
-    }
-
-    #historyToggle {
-      display: block;
-      position: absolute;
-      top: 15px;
-      right: 60px;
-      font-size: 20px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      padding: 5px;
-      color: var(--text-color-light);
-      line-height: 1;
-    }
-
-    #definitionToggle {
-      display: block;
-      position: absolute;
-      top: 15px;
-      right: 105px;
-      font-size: 20px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      padding: 5px;
-      color: var(--text-color-light);
-      line-height: 1;
-    }
 
     #optionsToggle {
       display: none;
@@ -183,10 +143,6 @@
     @media (min-width: 901px) {
       #historyClose,
       #definitionClose {
-        display: none;
-      }
-      #historyToggle,
-      #definitionToggle {
         display: none;
       }
       #optionsToggle {
@@ -887,17 +843,7 @@
           padding: 10px;
         }
 
-        #darkModeToggle {
-          display: none;
-        }
 
-      #historyToggle {
-        display: none;
-      }
-
-      #definitionToggle {
-        display: none;
-      }
 
       #optionsToggle {
         display: block;
@@ -1163,10 +1109,7 @@
       </div>
     </div>
 
-    <!-- Option Buttons -->
-    <button id="historyToggle" title="Show/Hide History">📜</button>
-    <button id="definitionToggle" title="Show/Hide Definition">📖</button>
-    <button id="darkModeToggle" title="Toggle Dark Mode">🌙</button>
+    <!-- Options Menu -->
     <div id="optionsMenu" style="display:none;">
       <button id="optionsClose" class="close-btn">✖</button>
       <button id="menuHistory">📜 History</button>

--- a/src/main.js
+++ b/src/main.js
@@ -27,9 +27,6 @@ const submitButton = document.getElementById('submitGuess');
 const messageEl = document.getElementById('message');
 const messagePopup = document.getElementById('messagePopup');
 const keyboard = document.getElementById('keyboard');
-const darkModeToggle = document.getElementById('darkModeToggle');
-const historyToggle = document.getElementById('historyToggle');
-const definitionToggle = document.getElementById('definitionToggle');
 const definitionText = document.getElementById('definitionText');
 const definitionBox = document.getElementById('definitionBox');
 const chatBox = document.getElementById('chatBox');
@@ -377,21 +374,23 @@ setupTypingListeners({
   isAnimating: () => false
 });
 
-darkModeToggle.addEventListener('click', () => {
+function toggleDarkMode() {
   const isDark = document.body.classList.toggle('dark-mode');
   localStorage.setItem('darkMode', isDark);
-  applyDarkModePreference(darkModeToggle);
-});
+  applyDarkModePreference(menuDarkMode);
+}
 
-historyToggle.addEventListener('click', () => {
+function toggleHistory() {
   togglePanel('history-open');
-});
+}
+
+function toggleDefinition() {
+  togglePanel('definition-open');
+}
+
 historyClose.addEventListener('click', () => {
   document.body.classList.remove('history-open');
   positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
-});
-definitionToggle.addEventListener('click', () => {
-  togglePanel('definition-open');
 });
 definitionClose.addEventListener('click', () => {
   document.body.classList.remove('definition-open');
@@ -419,16 +418,16 @@ optionsToggle.addEventListener('click', () => {
   optionsMenu.style.transform = '';
 });
 optionsClose.addEventListener('click', () => { optionsMenu.style.display = 'none'; });
-menuHistory.addEventListener('click', () => { historyToggle.click(); optionsMenu.style.display = 'none'; });
-menuDefinition.addEventListener('click', () => { definitionToggle.click(); optionsMenu.style.display = 'none'; });
+menuHistory.addEventListener('click', () => { toggleHistory(); optionsMenu.style.display = 'none'; });
+menuDefinition.addEventListener('click', () => { toggleDefinition(); optionsMenu.style.display = 'none'; });
 menuChat.addEventListener('click', () => {
   togglePanel('chat-open');
   optionsMenu.style.display = 'none';
 });
-menuDarkMode.addEventListener('click', () => { darkModeToggle.click(); });
+menuDarkMode.addEventListener('click', toggleDarkMode);
 closeCallOk.addEventListener('click', () => { closeCallPopup.style.display = 'none'; });
 
-applyDarkModePreference(darkModeToggle);
+applyDarkModePreference(menuDarkMode);
 applyLayoutMode();
 createBoard(board, maxRows);
 repositionResetButton();


### PR DESCRIPTION
## Summary
- clean up index.html by removing the old option buttons
- drop related CSS rules
- refactor JS to directly toggle panels and dark mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b36b0644c832f8d3cbb4426b6179f