### PR TITLE
Simplify UI typing updates

### DIFF
--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -1,5 +1,4 @@
 import { updateBoard } from './board.js';
-import { getState } from './api.js';
 
 export function handleVirtualKey(event, {guessInput, submitGuessHandler, isAnimating}, updateBoardFromTyping) {
   if (event.target.classList.contains('key') && !guessInput.disabled && !isAnimating()) {
@@ -62,7 +61,7 @@ export function setupTypingListeners({keyboardEl, guessInput, submitButton, subm
   });
 }
 
-export async function updateBoardFromTyping(boardEl, guessInput, rows, gameOver) {
-  const state = await getState();
+export function updateBoardFromTyping(boardEl, state, guessInput, rows, gameOver) {
+  if (!state) return;
   updateBoard(boardEl, state, guessInput, rows, gameOver);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -380,7 +380,7 @@ setupTypingListeners({
   guessInput,
   submitButton,
   submitGuessHandler,
-  updateBoardFromTyping: () => updateBoardFromTyping(board, guessInput, maxRows, gameOver),
+  updateBoardFromTyping: () => updateBoardFromTyping(board, latestState, guessInput, maxRows, gameOver),
   isAnimating: () => false
 });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,34 +53,6 @@ export function repositionResetButton() {
   }
 }
 
-function animatePanelToCenter(box) {
-  if (typeof box.getBoundingClientRect !== 'function') {
-    box.style.transition = '';
-    box.style.transform = '';
-    box.style.position = '';
-    box.style.top = '';
-    box.style.left = '';
-    return;
-  }
-  const rect = box.getBoundingClientRect();
-  const centerX = window.innerWidth / 2;
-  const centerY = window.innerHeight / 2;
-  const offsetX = centerX - (rect.left + rect.width / 2);
-  const offsetY = centerY - (rect.top + rect.height / 2);
-  box.style.transition = 'transform 0.3s ease, opacity 0.3s ease';
-  box.style.transform = 'translate(0, 0) scale(1)';
-  requestAnimationFrame(() => {
-    box.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(0)`;
-  });
-  setTimeout(() => {
-    box.style.transition = '';
-    box.style.transform = '';
-    box.style.position = '';
-    box.style.top = '';
-    box.style.left = '';
-  }, 310);
-}
-
 export function positionSidePanels(boardArea, historyBox, definitionBox, chatBox) {
   if (window.innerWidth > 900) {
     const boardRect = boardArea.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- drop unused `animatePanelToCenter` helper
- avoid network calls on each keystroke by letting `updateBoardFromTyping` use cached state
- pass latest state in `main.js`

## Testing
- `python -m pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_684c12708588832f8f98b1eab23a0628