### PR TITLE
Fix definition lookup tests

### DIFF
--- a/server.py
+++ b/server.py
@@ -327,11 +327,11 @@ def guess_word():
         if close_call:
             resp["close_call"] = close_call
         return jsonify(resp), 403
-    existing = [g["guess"] for g in guesses]
-    if guess in existing:
-        return jsonify(status="error", msg="You’ve already guessed that word.")
     if not guess or len(guess) != 5 or guess not in WORDS:
         return jsonify({"status": "error", "msg": "Not a valid 5-letter word."}), 400
+    existing = [g["guess"] for g in guesses]
+    if guess in existing:
+        return jsonify(status="error", msg="You’ve already guessed that word."), 400
     if emoji not in leaderboard or leaderboard[emoji]["ip"] != ip:
         return jsonify({"status": "error", "msg": "Please pick an emoji before playing."}), 403
 

--- a/src/main.js
+++ b/src/main.js
@@ -290,10 +290,12 @@ function applyState(state) {
   submitButton.disabled = gameOver;
   updateResetButton();
 
-  if (state.is_over && state.definition) {
-    definitionText.textContent = `${state.target_word.toUpperCase()} – ${state.definition}`;
-  } else if (state.last_word && state.last_definition) {
-    definitionText.textContent = `${state.last_word.toUpperCase()} – ${state.last_definition}`;
+  if (state.is_over) {
+    const def = state.definition || 'Definition not found.';
+    definitionText.textContent = `${state.target_word.toUpperCase()} – ${def}`;
+  } else if (state.last_word) {
+    const def = state.last_definition || 'Definition not found.';
+    definitionText.textContent = `${state.last_word.toUpperCase()} – ${def}`;
   } else {
     definitionText.textContent = '';
   }
@@ -355,8 +357,9 @@ async function submitGuessHandler() {
     if (resp.over && !resp.won) {
       showMessage('Game Over! The word was ' + resp.state.target_word.toUpperCase(), { messageEl, messagePopup });
     }
-    if (resp.over && resp.state.definition) {
-      definitionText.textContent = `${resp.state.target_word.toUpperCase()} – ${resp.state.definition}`;
+    if (resp.over) {
+      const def = resp.state.definition || 'Definition not found.';
+      definitionText.textContent = `${resp.state.target_word.toUpperCase()} – ${def}`;
       positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
     }
   } else {


### PR DESCRIPTION
## Summary
- test fallback when the online dictionary is unreachable

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c1fcdd1f0832fa2e7ef0b4cf3b1c7