### PR TITLE
Default sound off

### DIFF
--- a/index.html
+++ b/index.html
@@ -1138,7 +1138,7 @@
       <button id="menuDefinition">📖 Definition</button>
       <button id="menuChat">💬 Chat</button>
       <button id="menuDarkMode">🌙/☀️</button>
-      <button id="menuSound">🔊 Sound On</button>
+      <button id="menuSound">🔈 Sound Off</button>
     </div>
 
     <!-- Game History Panel -->

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,8 @@ let leaderboardScrolling = false;
 let leaderboardScrollTimeout = null;
 let hadNetworkError = false;
 
-let soundEnabled = localStorage.getItem('soundEnabled') !== 'false';
+// Default to sound off unless user explicitly enabled it
+let soundEnabled = localStorage.getItem('soundEnabled') === 'true';
 let audioCtx = null;
 
 let maxRows = 6;


### PR DESCRIPTION
## Summary
- default sound effects to off unless enabled by user

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c22b2db10832f817701142a7ebf28