### PR TITLE
Fix mobile chat popup positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -936,6 +936,7 @@
       #chatBox {
         position: fixed;
         bottom: 0;
+        left: 0;
         right: 0;
         width: 100%;
         max-height: 0;


### PR DESCRIPTION
## Summary
- ensure chatBox resets its `left` position in mobile layout

## Testing
- `python -m pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68545616f1d8832f8034b04aa305f98b