### PR TITLE
Improve mobile popup positioning

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -43,6 +43,8 @@ overview and should be kept up to date as features evolve.
 - Feedback includes toast messages for errors and game events, shake animation
   for invalid guesses, and transient point deltas after submissions.
 - All interactive elements must be accessible via keyboard and screen readers.
+- Popups opened from the options menu use a shared positioning helper so they
+  remain fully visible on small screens.
 
 ## 3. Server Integration
 

--- a/index.html
+++ b/index.html
@@ -134,6 +134,9 @@
       box-shadow: 2px 2px 8px var(--shadow-color-dark),
                   -2px -2px 8px var(--shadow-color-light);
       z-index: 70;
+      max-width: 90%;
+      max-height: 90vh;
+      overflow-y: auto;
     }
 
     #optionsMenu button {
@@ -888,14 +891,19 @@
           padding: 10px;
         }
 
+        #optionsMenu {
+          position: fixed;
+          left: 50%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+        }
 
-
-      #optionsToggle {
-        display: block;
-      }
-      #chatNotify {
-        display: block;
-      }
+        #optionsToggle {
+          display: block;
+        }
+        #chatNotify {
+          display: block;
+        }
 
       #historyBox {
         position: fixed;

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,8 @@ import { getMyEmoji, setMyEmoji, showEmojiModal } from './emoji.js';
 import { getState, sendGuess, resetGame, sendHeartbeat, sendChatMessage } from './api.js';
 import { renderChat } from './chat.js';
 import { setupTypingListeners, updateBoardFromTyping } from './keyboard.js';
-import { showMessage, applyDarkModePreference, shakeInput, repositionResetButton, positionSidePanels, updateVH, applyLayoutMode, isMobile } from './utils.js';
+import { showMessage, applyDarkModePreference, shakeInput, repositionResetButton,
+         positionSidePanels, updateVH, applyLayoutMode, isMobile, showPopup } from './utils.js';
 
 let activeEmojis = [];
 let leaderboard = [];
@@ -479,21 +480,7 @@ chatNotify.addEventListener('click', () => {
   hideChatNotify();
 });
 optionsToggle.addEventListener('click', () => {
-  optionsMenu.style.display = 'block';
-  const rect = optionsToggle.getBoundingClientRect();
-  optionsMenu.style.position = 'absolute';
-  const menuWidth = optionsMenu.offsetWidth;
-  let left;
-  if (window.innerWidth - rect.right >= menuWidth + 10) {
-    left = rect.right + 10 + window.scrollX;
-  } else if (rect.left >= menuWidth + 10) {
-    left = rect.left - menuWidth - 10 + window.scrollX;
-  } else {
-    left = Math.max(10 + window.scrollX, window.innerWidth - menuWidth - 10);
-  }
-  optionsMenu.style.left = `${left}px`;
-  optionsMenu.style.top = `${rect.top + window.scrollY}px`;
-  optionsMenu.style.transform = '';
+  showPopup(optionsMenu, optionsToggle);
 });
 optionsClose.addEventListener('click', () => { optionsMenu.style.display = 'none'; });
 menuHistory.addEventListener('click', () => { toggleHistory(); optionsMenu.style.display = 'none'; });

--- a/src/utils.js
+++ b/src/utils.js
@@ -105,3 +105,30 @@ export function applyLayoutMode() {
     document.body.dataset.mode = mode;
   }
 }
+
+export function positionPopup(popup, anchor) {
+  const rect = anchor.getBoundingClientRect();
+  const menuWidth = popup.offsetWidth;
+  const menuHeight = popup.offsetHeight;
+  let left = rect.right + 10 + window.scrollX;
+  if (window.innerWidth - rect.right < menuWidth + 10) {
+    if (rect.left >= menuWidth + 10) {
+      left = rect.left - menuWidth - 10 + window.scrollX;
+    } else {
+      left = Math.max(10 + window.scrollX, window.innerWidth - menuWidth - 10);
+    }
+  }
+  let top = rect.top + window.scrollY;
+  if (rect.bottom + menuHeight > window.scrollY + window.innerHeight - 10) {
+    top = window.scrollY + window.innerHeight - menuHeight - 10;
+  }
+  top = Math.max(top, window.scrollY + 10);
+  popup.style.position = 'absolute';
+  popup.style.left = `${left}px`;
+  popup.style.top = `${top}px`;
+}
+
+export function showPopup(popup, anchor) {
+  popup.style.display = 'block';
+  positionPopup(popup, anchor);
+}

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -85,9 +85,10 @@ def test_popups_fill_viewport():
 
 
 def test_options_menu_clamped_to_viewport():
-    text = (SRC_DIR / 'main.js').read_text(encoding='utf-8')
-    assert 'window.innerWidth - rect.right' in text
-    assert 'Math.max(10 + window.scrollX' in text
+    main_text = (SRC_DIR / 'main.js').read_text(encoding='utf-8')
+    utils_text = (SRC_DIR / 'utils.js').read_text(encoding='utf-8')
+    assert 'showPopup(optionsMenu, optionsToggle)' in main_text
+    assert 'export function positionPopup' in utils_text
 
 
 def test_side_panels_fixed_to_bottom_in_light_mode():


### PR DESCRIPTION
## Summary
- add CSS rules so options menu is usable on small screens
- export `positionPopup` and `showPopup` helpers
- use `showPopup` when opening the options menu
- document popup positioning requirement
- update tests for new helper

## Testing
- `python -m pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68546516778c832fbefb3086cc207c08