### PR TITLE
refactor: extract board layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ is required for the full suite to run successfully.
 
 - `server.py` – Flask backend
 - `index.html` – browser client
+- `layout.css` – shared board and menu layout
 - `neumorphic.css` – neumorphic theme styles
 - `sgb-words.txt` – word list used by the game
 - `tests/` – Pytest suite

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>Wordle Game (Hard Mode, Shared)</title>
+  <link rel="stylesheet" href="layout.css">
   <link rel="stylesheet" href="neumorphic.css" id="themeStylesheet">
 
 </head>

--- a/layout.css
+++ b/layout.css
@@ -1,0 +1,103 @@
+/* Shared layout for game board and controls */
+:root {
+  --board-tile-size: 60px;
+  --board-gap: 10px;
+  --board-max-width: 340px;
+  --tile-font-size: 28px;
+  --tile-radius: 8px;
+  --key-min-width: 35px;
+  --key-height: 50px;
+  --key-font-size: 16px;
+  --key-radius: 8px;
+}
+
+body[data-mode='light'] {
+  --board-tile-size: 50px;
+  --board-gap: 5px;
+  --board-max-width: 260px;
+  --tile-font-size: 22px;
+  --tile-radius: 4px;
+  --key-min-width: 32px;
+  --key-height: 48px;
+}
+
+body[data-mode='medium'] {
+  --board-tile-size: 55px;
+  --board-gap: 8px;
+  --board-max-width: 307px;
+  --key-min-width: 34px;
+  --key-height: 50px;
+}
+
+#board {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(5, var(--board-tile-size));
+  grid-gap: var(--board-gap);
+  max-width: var(--board-max-width);
+}
+
+#boardArea {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  margin: 20px auto;
+  width: max-content;
+  position: relative;
+}
+
+.tile {
+  width: var(--board-tile-size);
+  height: var(--board-tile-size);
+  font-size: var(--tile-font-size);
+  font-weight: bold;
+  text-transform: uppercase;
+  border-radius: var(--tile-radius);
+}
+
+#keyboard {
+  display: inline-block;
+  margin-top: 5px;
+}
+
+.keyboard-row {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+.key {
+  min-width: var(--key-min-width);
+  height: var(--key-height);
+  margin: 3px;
+  border-radius: var(--key-radius);
+  font-size: var(--key-font-size);
+  font-weight: 500;
+  text-transform: uppercase;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+}
+
+#historyBox {
+  top: 0;
+  left: auto;
+  right: calc(100% + 20px);
+  transform-origin: right center;
+}
+
+#definitionBox {
+  top: 0;
+  right: auto;
+  left: calc(100% + 20px);
+  transform-origin: left center;
+}
+
+body:not(.history-open) #historyBox,
+body:not(.definition-open) #definitionBox {
+  transform: scale(0);
+  opacity: 0;
+  pointer-events: none;
+}

--- a/neumorphic.css
+++ b/neumorphic.css
@@ -183,32 +183,6 @@
       #boardArea {
         position: relative;
       }
-      #historyBox {
-        top: 0;
-        left: auto;
-        right: calc(100% + 20px);
-      }
-      #definitionBox {
-        top: 0;
-        right: auto;
-        left: calc(100% + 20px);
-      }
-      #historyBox {
-        transform-origin: right center;
-      }
-      #definitionBox {
-        transform-origin: left center;
-      }
-      body:not(.history-open) #historyBox {
-        transform: scale(0);
-        opacity: 0;
-        pointer-events: none;
-      }
-      body:not(.definition-open) #definitionBox {
-        transform: scale(0);
-        opacity: 0;
-        pointer-events: none;
-      }
       #chatBox {
         transform-origin: left center;
       }
@@ -421,23 +395,6 @@
     }
 
     /* ─── Board and Tiles ─── */
-    #board {
-      margin: 0;
-      display: grid;
-      grid-template-columns: repeat(5, 60px);
-      grid-gap: 10px;
-      max-width: 340px;
-    }
-
-    #boardArea {
-      display: flex;
-      justify-content: center;
-      align-items: flex-end;
-      margin: 20px auto;
-      width: max-content;
-      position: relative;
-    }
-
     #stampContainer {
       position: absolute;
       top: 0;
@@ -460,17 +417,11 @@
     }
 
     .tile {
-      width: 60px;
-      height: 60px;
       border: 1px solid var(--border-color);
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 28px;
-      font-weight: bold;
-      text-transform: uppercase;
       background-color: var(--tile-bg);
-      border-radius: 8px;
       box-shadow: 5px 5px 10px var(--shadow-color-dark),
                   -5px -5px 10px var(--shadow-color-light);
       transition: background-color 0.3s, color 0.3s, border-color 0.3s,
@@ -611,15 +562,8 @@
     }
 
     .key {
-      min-width: 35px;
-      height: 50px;
-      margin: 3px;
       border: none;
       background-color: var(--key-bg);
-      border-radius: 8px;
-      font-size: 16px;
-      font-weight: 500;
-      text-transform: uppercase;
       cursor: pointer;
       color: var(--key-text);
       box-shadow: 4px 4px 8px var(--shadow-color-dark),
@@ -1041,17 +985,9 @@
       }
 
       #board {
-        grid-template-columns: repeat(5, 50px);
-        grid-gap: 5px;
-        max-width: 260px;
-        margin: 0;
       }
 
       .tile {
-        width: 50px;
-        height: 50px;
-        font-size: 22px;
-        border-radius: 4px;
         box-shadow: 3px 3px 6px var(--shadow-color-dark),
                     -3px -3px 6px var(--shadow-color-light);
       }
@@ -1067,14 +1003,9 @@
       }
 
       .key {
-        min-width: 32px;
-        height: 48px;
-        margin: 2px;
-        font-size: 16px;
         padding: 0 5px;
         box-shadow: 3px 3px 6px var(--shadow-color-dark),
                     -3px -3px 6px var(--shadow-color-light);
-        border-radius: 6px;
       }
 
 
@@ -1163,18 +1094,11 @@
       }
 
       #board {
-        grid-template-columns: repeat(5, 55px);
-        grid-gap: 8px;
-        max-width: 307px;
       }
 
       .tile {
-        width: 55px;
-        height: 55px;
       }
 
       .key {
-        min-width: 34px;
-        height: 50px;
       }
     }

--- a/server.py
+++ b/server.py
@@ -467,9 +467,9 @@ def index():
 def src_files(filename):
     return send_from_directory('src', filename)
 
-# Serve any CSS file in the repository root
+# Serve any CSS file in the repository root (e.g. neumorphic.css, layout.css)
 @app.route('/<path:filename>.css')
-def theme_css(filename):
+def theme_css(filename: str):
     """Serve CSS assets from the project root."""
     return send_from_directory('.', f"{filename}.css")
 

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -26,6 +26,7 @@ def test_modules_exist_and_export():
 
 def test_index_html_uses_module_script():
     text = INDEX.read_text(encoding='utf-8')
+    assert '<link rel="stylesheet" href="layout.css"' in text
     assert '<link rel="stylesheet" href="neumorphic.css"' in text
     scripts = re.findall(r'<script[^>]*>.*?</script>', text, flags=re.DOTALL)
     assert len(scripts) == 1, "index.html should contain exactly one script tag"
@@ -49,7 +50,7 @@ def test_definition_panel_elements_exist():
 
 
 def test_definition_panel_css_rules():
-    css = CSS_FILE.read_text(encoding='utf-8')
+    css = CSS_FILE.read_text(encoding='utf-8') + Path('layout.css').read_text(encoding='utf-8')
     assert 'body:not(.definition-open) #definitionBox' in css
     assert 'body.definition-open #definitionBox' in css
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -661,3 +661,10 @@ def test_chat_post_and_get(server_env):
     data = server.chat()
     assert data['messages'][-1]['text'] == 'hello'
 
+
+def test_css_routes_serve_files(server_env):
+    server, _ = server_env
+
+    assert server.theme_css('layout') == './layout.css'
+    assert server.theme_css('neumorphic') == './neumorphic.css'
+


### PR DESCRIPTION
## Summary
- create `layout.css` for shared board and menu layout
- reference the new stylesheet from `index.html`
- trim layout properties from `neumorphic.css`
- document `layout.css` in the README
- update frontend tests for the new stylesheet
- add test for serving CSS assets

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c02b8ac0c832f943743ab276a886c