### PR TITLE
Fix reset race and unwanted popup

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -60,6 +60,8 @@ const stampContainer = document.getElementById('stampContainer');
 const closeCallPopup = document.getElementById('closeCallPopup');
 const closeCallText = document.getElementById('closeCallText');
 const closeCallOk = document.getElementById('closeCallOk');
+// Ensure the close-call popup starts hidden even if CSS hasn't loaded yet
+closeCallPopup.style.display = 'none';
 const chatNotify = document.getElementById('chatNotify');
 const infoPopup = document.getElementById('infoPopup');
 const infoClose = document.getElementById('infoClose');
@@ -227,6 +229,17 @@ async function performReset() {
   showMessage('Game reset!', { messageEl, messagePopup });
 }
 
+async function quickResetHandler() {
+  // Ensure our view is up to date before attempting a one-click reset.
+  await fetchState();
+  if (!latestState.is_over) {
+    // Another player already started a new round; switch to hold-to-reset mode.
+    showMessage('Board already reset.', { messageEl, messagePopup });
+    return;
+  }
+  await performReset();
+}
+
 function updateResetButton() {
   if (gameOver) {
     holdResetText.textContent = 'Reset';
@@ -234,7 +247,7 @@ function updateResetButton() {
     holdResetProgress.style.opacity = '0';
     holdReset.onmousedown = null;
     holdReset.ontouchstart = null;
-    holdReset.onclick = () => { performReset(); };
+    holdReset.onclick = () => { quickResetHandler(); };
   } else {
     holdResetText.textContent = 'Reset';
     holdResetProgress.style.opacity = '0.9';

--- a/offline_definitions.json
+++ b/offline_definitions.json
@@ -3,5 +3,6 @@
   "enter": "to go or come into",
   "crane": "a large bird or lifting machine",
   "crate": "a large shipping container",
+  "reeee": "what a deeply internet-poisoned frog yells when life just isn’t vibing right.",
   "trace": "a mark or sign left by something"
 }

--- a/sgb-words.txt
+++ b/sgb-words.txt
@@ -1557,6 +1557,7 @@ recap
 recur
 recut
 reedy
+reeee
 refer
 refit
 regal


### PR DESCRIPTION
## Summary
- hide the close call popup on load to stop spurious OK dialog
- prevent stale one-click reset by checking the latest state before resetting
- add the word **reeee** to the allowed list with an offline definition

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4c15e698832f9c2d586194875428