### PR TITLE
Fix options gear positioning on medium and mobile view

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -15,9 +15,13 @@
 
         #optionsToggle {
           display: block;
+          left: auto;
+          right: 0;
         }
         #chatNotify {
           display: block;
+          left: auto;
+          right: 0;
         }
 
       #historyBox {
@@ -215,6 +219,12 @@
 
       #optionsToggle {
         display: block;
+        left: auto;
+        right: 0;
+      }
+      #chatNotify {
+        left: auto;
+        right: 0;
       }
 
       body[data-mode='medium'] #historyClose,


### PR DESCRIPTION
## Summary
- ensure optionsToggle and chatNotify buttons stay visible on small screens by placing them inside the board area

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d62708710832f973bfb012add8c44