### PR TITLE
Fix options visibility and dark mode label

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -369,7 +369,7 @@
 
 
     #optionsToggle {
-      display: none;
+      display: block;
       font-size: 28px;
       background: none;
       border: none;
@@ -383,7 +383,7 @@
     }
 
     #chatNotify {
-      display: none;
+      display: block;
       font-size: 26px;
       background: none;
       border: none;
@@ -394,13 +394,12 @@
       position: absolute;
       top: 36px;
       left: calc(100% + 10px);
-      opacity: 0;
-      transform: scale(0);
+      opacity: 1;
+      transform: scale(1);
       transition: opacity 0.3s, transform 0.3s;
       z-index: 60;
     }
     #chatNotify.visible {
-      display: block;
       opacity: 1;
       transform: scale(1);
     }

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -146,7 +146,6 @@ function showChatNotify() {
 
 function hideChatNotify() {
   chatNotify.classList.remove('visible');
-  chatNotify.style.display = 'none';
   clearTimeout(chatWiggleTimer);
 }
 

--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -29,7 +29,7 @@ export function showMessage(msg, {messageEl, messagePopup}) {
 export function applyDarkModePreference(toggle) {
   const prefersDark = localStorage.getItem('darkMode') === 'true';
   document.body.classList.toggle('dark-mode', prefersDark);
-  toggle.textContent = prefersDark ? '☀️' : '🌙';
+  toggle.textContent = prefersDark ? '☀️ Light Mode' : '🌙 Dark Mode';
   toggle.title = prefersDark ? 'Switch to Light Mode' : 'Switch to Dark Mode';
 }
 


### PR DESCRIPTION
## Summary
- ensure options gear and chat icons are visible on all layouts
- keep chat icon visible after opening chat
- show text label for dark/light mode toggle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d72be1124832fbe0c4c74dd729be0