### PR TITLE
Add focus management for accessibility

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ as they are completed.
 ## Accessibility
 
 - [ ] Add additional ARIA roles for interactive elements.
-- [ ] Implement focus management for keyboard users.
+ - [x] Implement focus management for keyboard users.
 - [ ] Verify color contrast and adjust themes if necessary.
 
 ## Backend Integration

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,9 +11,9 @@
 <body>
   <div id="appContainer">
     <!-- Emoji Picker Modal -->
-    <div id="emojiModal">
+    <div id="emojiModal" role="dialog" aria-modal="true" aria-labelledby="emojiModalHeading">
       <div id="emojiModalBox">
-        <div>
+        <div id="emojiModalHeading">
           Pick your emoji for this game:
         </div>
         <div id="emojiChoices"></div>
@@ -22,7 +22,7 @@
     </div>
 
     <!-- Close Call Popup -->
-    <div id="closeCallPopup">
+    <div id="closeCallPopup" role="alertdialog" aria-modal="true" aria-labelledby="closeCallText">
       <div id="closeCallBox">
         <div id="closeCallText"></div>
         <button id="closeCallOk">OK</button>
@@ -30,7 +30,7 @@
     </div>
 
     <!-- Info Popup -->
-    <div id="infoPopup">
+    <div id="infoPopup" role="dialog" aria-modal="true" aria-label="Game information">
       <div id="infoBox">
         <button id="infoClose" class="close-btn">✖</button>
         <div id="infoContent">
@@ -45,7 +45,7 @@
     </div>
 
     <!-- Options Menu -->
-    <div id="optionsMenu">
+    <div id="optionsMenu" role="dialog" aria-modal="true" aria-label="Options menu">
       <button id="optionsClose" class="close-btn">✖</button>
       <button id="menuHistory">📜 History</button>
       <button id="menuDefinition">📖 Definition</button>
@@ -56,20 +56,22 @@
     </div>
 
     <!-- Game History Panel -->
-    <div id="historyBox">
+    <div id="historyBox" role="dialog" aria-modal="true" aria-labelledby="historyHeading">
       <button id="historyClose" class="close-btn">✖</button>
-      <h3>History</h3>
+      <h3 id="historyHeading">History</h3>
       <ul id="historyList"></ul>
     </div>
 
     <!-- Leaderboard -->
-    <div id="leaderboard"></div>
-    <div id="definitionBox">
+    <div id="leaderboard" role="region" aria-label="Leaderboard"></div>
+    <div id="definitionBox" role="dialog" aria-modal="true" aria-labelledby="definitionHeading">
       <button id="definitionClose" class="close-btn">✖</button>
+      <h3 id="definitionHeading" class="visually-hidden">Definition</h3>
       <div id="definitionText"></div>
     </div>
-    <div id="chatBox">
+    <div id="chatBox" role="dialog" aria-modal="true" aria-labelledby="chatHeading">
       <button id="chatClose" class="close-btn" type="button">✖</button>
+      <h3 id="chatHeading" class="visually-hidden">Chat</h3>
       <div id="chatMessages"></div>
       <form id="chatForm">
         <input id="chatInput" type="text" maxlength="140" autocomplete="off" />
@@ -90,7 +92,7 @@
 
     <!-- Board -->
     <div id="boardArea">
-      <div id="board"></div>
+      <div id="board" role="grid" aria-label="Guess grid"></div>
       <div id="stampContainer"></div>
       <button id="optionsToggle" title="More Options">⚙️</button>
       <button id="chatNotify" title="Open Chat">💬</button>

--- a/frontend/static/css/theme.css
+++ b/frontend/static/css/theme.css
@@ -75,3 +75,15 @@ body {
   -moz-user-select: text;
   -ms-user-select: text;
 }
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/static/js/emoji.js
+++ b/frontend/static/js/emoji.js
@@ -1,4 +1,5 @@
 import { sendEmoji } from './api.js';
+import { openDialog, closeDialog } from './utils.js';
 
 export function getMyEmoji() {
   return localStorage.getItem('myEmoji') || null;
@@ -35,7 +36,7 @@ export function showEmojiModal(takenEmojis, {
         if (skipAutoCloseRef) skipAutoCloseRef.value = false;
         setMyEmoji(e);
         if (typeof onChosen === 'function') onChosen(e);
-        modal.style.display = 'none';
+        closeDialog(modal);
       } else {
         errorEl.textContent = data.msg || 'That emoji is taken.';
       }
@@ -45,5 +46,6 @@ export function showEmojiModal(takenEmojis, {
   });
 
   errorEl.textContent = '';
-  modal.style.display = '';
+  modal.style.display = 'flex';
+  openDialog(modal);
 }

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -5,7 +5,8 @@ import { getState, sendGuess, resetGame, sendHeartbeat, sendChatMessage, subscri
 import { renderChat } from './chat.js';
 import { setupTypingListeners, updateBoardFromTyping } from './keyboard.js';
 import { showMessage, announce, applyDarkModePreference, shakeInput, repositionResetButton,
-         positionSidePanels, updateVH, applyLayoutMode, isMobile, showPopup } from './utils.js';
+         positionSidePanels, updateVH, applyLayoutMode, isMobile, showPopup,
+         openDialog, closeDialog, focusFirstElement } from './utils.js';
 
 let activeEmojis = [];
 let leaderboard = [];
@@ -377,7 +378,7 @@ function applyState(state) {
     });
     showEmojiModalOnNextFetch = false;
   } else if (!skipAutoClose) {
-    document.getElementById('emojiModal').style.display = 'none';
+    closeDialog(document.getElementById('emojiModal'));
   }
 }
 
@@ -438,6 +439,7 @@ async function submitGuessHandler() {
     if (resp.close_call) {
       closeCallText.textContent = `Close call! ${resp.close_call.winner} beat you by ${resp.close_call.delta_ms}ms.`;
       closeCallPopup.style.display = 'flex';
+      openDialog(closeCallPopup);
     } else {
       showMessage(resp.msg, { messageEl, messagePopup });
     }
@@ -515,14 +517,21 @@ function toggleSound() {
 
 function toggleHistory() {
   togglePanel('history-open');
+  if (document.body.classList.contains('history-open')) {
+    focusFirstElement(historyBox);
+  }
 }
 
 function toggleDefinition() {
   togglePanel('definition-open');
+  if (document.body.classList.contains('definition-open')) {
+    focusFirstElement(definitionBoxEl);
+  }
 }
 
 function showInfo() {
   infoPopup.style.display = 'flex';
+  openDialog(infoPopup);
 }
 
 historyClose.addEventListener('click', () => {
@@ -540,23 +549,29 @@ chatClose.addEventListener('click', () => {
 chatNotify.addEventListener('click', () => {
   togglePanel('chat-open');
   hideChatNotify();
+  if (document.body.classList.contains('chat-open')) {
+    focusFirstElement(chatBox);
+  }
 });
 optionsToggle.addEventListener('click', () => {
   showPopup(optionsMenu, optionsToggle);
 });
-optionsClose.addEventListener('click', () => { optionsMenu.style.display = 'none'; });
-menuHistory.addEventListener('click', () => { toggleHistory(); optionsMenu.style.display = 'none'; });
-menuDefinition.addEventListener('click', () => { toggleDefinition(); optionsMenu.style.display = 'none'; });
+optionsClose.addEventListener('click', () => { closeDialog(optionsMenu); });
+menuHistory.addEventListener('click', () => { toggleHistory(); closeDialog(optionsMenu); });
+menuDefinition.addEventListener('click', () => { toggleDefinition(); closeDialog(optionsMenu); });
 menuChat.addEventListener('click', () => {
   togglePanel('chat-open');
   hideChatNotify();
-  optionsMenu.style.display = 'none';
+  if (document.body.classList.contains('chat-open')) {
+    focusFirstElement(chatBox);
+  }
+  closeDialog(optionsMenu);
 });
-menuInfo.addEventListener('click', () => { showInfo(); optionsMenu.style.display = 'none'; });
+menuInfo.addEventListener('click', () => { showInfo(); closeDialog(optionsMenu); });
 menuDarkMode.addEventListener('click', toggleDarkMode);
 menuSound.addEventListener('click', toggleSound);
-closeCallOk.addEventListener('click', () => { closeCallPopup.style.display = 'none'; });
-infoClose.addEventListener('click', () => { infoPopup.style.display = 'none'; });
+closeCallOk.addEventListener('click', () => { closeDialog(closeCallPopup); });
+infoClose.addEventListener('click', () => { closeDialog(infoPopup); });
 
 applyDarkModePreference(menuDarkMode);
 menuSound.textContent = soundEnabled ? '🔊 Sound On' : '🔈 Sound Off';


### PR DESCRIPTION
## Summary
- implement `openDialog`/`closeDialog` utilities for focus trapping
- manage focus when popups and side panels open
- update emoji modal and other dialogs to restore focus on close
- mark focus management task complete in TODO

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc6c82d5c832fb187c69c13cd9314