### PR TITLE
Add Daily Double confetti effect

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -44,8 +44,8 @@ as they are completed.
  - [x] Animate tile reveal after each guess.
  - [x] Add optional sound effects with on/off toggle.
  - [x] Close-Call Notifications: design a neumorphic popup/overlay.
- - [ ] Daily Double FX:
-   - Confetti/particle burst on the qualifying tile.
+- [ ] Daily Double FX:
+   - [x] Confetti/particle burst on the qualifying tile.
    - Ghost-style preview for the chosen hint tile.
    - Tooltip/toast informing the player they earned a hint.
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -499,6 +499,8 @@ def guess_word():
     guesses.append(new_entry)
 
     dd_award = False
+    award_row = None
+    award_col = None
     if daily_double_index is not None:
         dd_row = daily_double_index // 5
         dd_col = daily_double_index % 5
@@ -506,6 +508,8 @@ def guess_word():
             daily_double_winners.add(emoji)
             daily_double_pending[emoji] = row_index + 1
             dd_award = True
+            award_row = dd_row
+            award_col = dd_col
 
     # Points logic: Only award for globally new discoveries!
     global_found_this_turn = set()
@@ -562,15 +566,18 @@ def guess_word():
     resp_state = build_state_payload(emoji)
     broadcast_state()
 
-    return jsonify({
+    resp = {
         "status": "ok",
         "pointsDelta": points_delta,
         "state": resp_state,
         "won": won,
         "over": over,
         "daily_double": dd_award,
-        "daily_double_available": emoji in daily_double_pending
-    })
+        "daily_double_available": emoji in daily_double_pending,
+    }
+    if dd_award:
+        resp["daily_double_tile"] = {"row": award_row, "col": award_col}
+    return jsonify(resp)
 
 
 @app.route("/hint", methods=["POST"])

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -755,6 +755,21 @@
       line-height: 1;
     }
 
+    .confetti-container {
+      position: absolute;
+      width: 0;
+      height: 0;
+      pointer-events: none;
+      z-index: 6;
+    }
+
+    .confetti-piece {
+      position: absolute;
+      width: 6px;
+      height: 6px;
+      border-radius: 1px;
+    }
+
     body[data-mode='medium'] #stampContainer {
       display: block;
     }


### PR DESCRIPTION
## Summary
- send tile row/col in daily double award response
- burst confetti on the daily double tile
- style confetti pieces
- check off TODO item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685deeb78318832fb4ee8bb3b41fd377