### PR TITLE
Add victory jingle feature

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,7 @@ This file tracks outstanding tasks for "Wordle with Friends". Completed items ar
 
 - [x] Provide a fully keyboard-driven flow for Daily Double selection
       (toggle `.hint-selecting` on badge click or `Space`, constrain focus to eligible tiles).
-- [ ] Optional jingle should respect the sound toggle and announce via `#ariaLive`.
+- [x] Optional jingle should respect the sound toggle and announce via `#ariaLive`.
 
 ## Testing
 

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -180,6 +180,26 @@ function playClick() {
   osc.stop(audioCtx.currentTime + 0.05);
 }
 
+function playJingle() {
+  if (!soundEnabled) return;
+  if (!audioCtx) {
+    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  }
+  const notes = [523.25, 659.25, 783.99];
+  notes.forEach((freq, i) => {
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(freq, audioCtx.currentTime + i * 0.2);
+    gain.gain.setValueAtTime(0.15, audioCtx.currentTime + i * 0.2);
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    osc.start(audioCtx.currentTime + i * 0.2);
+    osc.stop(audioCtx.currentTime + i * 0.2 + 0.18);
+  });
+  announce('Jingle playing');
+}
+
 function showChatNotify() {
   chatNotify.style.display = 'block';
   requestAnimationFrame(() => chatNotify.classList.add('visible'));
@@ -477,6 +497,7 @@ async function submitGuessHandler() {
     if (typeof resp.pointsDelta === 'number') showPointsDelta(resp.pointsDelta);
     if (resp.won) {
       showMessage('You got it! The word was ' + resp.state.target_word.toUpperCase(), { messageEl, messagePopup });
+      playJingle();
     }
     if (resp.over && !resp.won) {
       showMessage('Game Over! The word was ' + resp.state.target_word.toUpperCase(), { messageEl, messagePopup });

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -392,3 +392,9 @@ console.log(JSON.stringify({ afterDisable, afterEnable }));
     data = json.loads(result.stdout.strip())
     assert data['afterDisable'] == [True, True, True]
     assert data['afterEnable'] == [False, False, False]
+
+
+def test_play_jingle_function_present():
+    text = (SRC_DIR / 'main.js').read_text(encoding='utf-8')
+    assert 'function playJingle()' in text
+    assert 'announce(' in text


### PR DESCRIPTION
## Summary
- implement `playJingle()` in main.js with Web Audio
- announce jingle via `ariaLive` region and respect sound toggle
- play jingle when the winning guess is submitted
- check off completed task in TODO
- test for presence of jingle function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e77dd9320832f8557bec1b4ed385e