### PR TITLE
Add hint badge update unit test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,7 @@ This file tracks outstanding tasks for "Wordle with Friends". Completed items ar
 
 ## Testing
 
-- [ ] Unit test hint badge visibility and disappearance.
+- [x] Unit test hint badge visibility and disappearance.
 - [ ] Integration test reconnecting with an active Daily Double hint.
 - [ ] A11y test for live region announcements and color contrast.
 - [ ] Expand unit tests to cover additional API and UI logic.

--- a/frontend/static/js/hintBadge.js
+++ b/frontend/static/js/hintBadge.js
@@ -1,0 +1,5 @@
+export function updateHintBadge(badgeEl, available) {
+  if (!badgeEl) return;
+  badgeEl.style.display = available ? 'inline' : 'none';
+}
+

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -7,6 +7,7 @@ import { setupTypingListeners, updateBoardFromTyping } from './keyboard.js';
 import { showMessage, announce, applyDarkModePreference, shakeInput, repositionResetButton,
          positionSidePanels, updateVH, applyLayoutMode, isMobile, showPopup,
          openDialog, closeDialog, focusFirstElement, setGameInputDisabled } from './utils.js';
+import { updateHintBadge } from './hintBadge.js';
 
 let activeEmojis = [];
 let leaderboard = [];
@@ -379,7 +380,7 @@ function applyState(state) {
   leaderboard = state.leaderboard || [];
   dailyDoubleAvailable = !!state.daily_double_available;
   renderLeaderboard();
-  titleHintBadge.style.display = dailyDoubleAvailable ? 'inline' : 'none';
+  updateHintBadge(titleHintBadge, dailyDoubleAvailable);
 
   if (state.chat_messages) {
     renderChat(chatMessagesEl, state.chat_messages);

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -398,3 +398,22 @@ def test_play_jingle_function_present():
     text = (SRC_DIR / 'main.js').read_text(encoding='utf-8')
     assert 'function playJingle()' in text
     assert 'announce(' in text
+
+
+def test_update_hint_badge_toggles_display():
+    script = """
+import { updateHintBadge } from './frontend/static/js/hintBadge.js';
+const badge = { style: { display: 'none' } };
+updateHintBadge(badge, true);
+const afterTrue = badge.style.display;
+updateHintBadge(badge, false);
+const afterFalse = badge.style.display;
+console.log(JSON.stringify({ afterTrue, afterFalse }));
+"""
+    result = subprocess.run(
+        ['node', '--input-type=module', '-e', script],
+        capture_output=True, text=True, check=True
+    )
+    data = json.loads(result.stdout.strip())
+    assert data['afterTrue'] == 'inline'
+    assert data['afterFalse'] == 'none'


### PR DESCRIPTION
## Summary
- introduce `hintBadge.js` to manage title hint visibility
- use `updateHintBadge` in `main.js`
- test hint badge toggle behaviour
- check off completed task in TODO

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7a9bc560832f9756d10e7ea7d6ed