### PR TITLE
Preserve score when changing emoji

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -436,18 +436,29 @@ def set_emoji():
 
         prev_emoji = ip_to_emoji.get(ip)
         if prev_emoji and prev_emoji != emoji:
-            leaderboard.pop(prev_emoji, None)
-
-        leaderboard[emoji] = leaderboard.get(
-            emoji,
-            {
-                "ip": ip,
-                "score": 0,
-                "used_yellow": [],
-                "used_green": [],
-                "last_active": now,
-            },
-        )
+            # Move existing entry so score and history persist
+            entry = leaderboard.pop(
+                prev_emoji,
+                {
+                    "ip": ip,
+                    "score": 0,
+                    "used_yellow": [],
+                    "used_green": [],
+                    "last_active": now,
+                },
+            )
+            leaderboard[emoji] = entry
+        else:
+            leaderboard.setdefault(
+                emoji,
+                {
+                    "ip": ip,
+                    "score": 0,
+                    "used_yellow": [],
+                    "used_green": [],
+                    "last_active": now,
+                },
+            )
         leaderboard[emoji]["ip"] = ip
         leaderboard[emoji]["last_active"] = now
         ip_to_emoji[ip] = emoji

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -201,10 +201,11 @@ def test_set_emoji_duplicate_different_ip(server_env):
     assert '3' not in server.ip_to_emoji
 
 
-def test_set_emoji_changes_remove_previous(server_env):
+def test_set_emoji_changes_migrate_score(server_env):
     server, request = server_env
 
     # establish initial mapping for ip '1'
+    server.leaderboard['😀']['score'] = 5
     request.json = {'emoji': '😀'}
     request.remote_addr = '1'
     resp1 = server.set_emoji()
@@ -219,6 +220,7 @@ def test_set_emoji_changes_remove_previous(server_env):
     assert server.ip_to_emoji['1'] == '🥳'
     assert '🥳' in server.leaderboard
     assert '😀' not in server.leaderboard
+    assert server.leaderboard['🥳']['score'] == 5
 
 
 def test_state_get_returns_sorted_leaderboard(server_env):


### PR DESCRIPTION
## Summary
- keep leaderboard score when changing emoji
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea23d59c0832f9a05ff73a3cfae8d