### PR TITLE
Add landing page storage helpers tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@ This file tracks outstanding tasks for "Wordle with Friends". Completed items ar
 - [x] Display a re-join chip using the last saved lobby code.
 - [x] Add a sticky header with theme toggle plus Help and GitHub links.
 - [x] Show feature highlight cards and a collapsible How-to-Play accordion.
-- [ ] Persist dark mode, emoji, and last lobby code in `localStorage`.
+- [x] Persist dark mode, emoji, and last lobby code in `localStorage`.
 - [x] Write Jest DOM tests for rendering, validation, and preference storage.
 - [ ] Display lobby header with code, player count, and host controls.
 - [ ] Persist emoji across reloads and reclaim it via `POST /lobby/<id>/emoji`.

--- a/frontend/landing.js
+++ b/frontend/landing.js
@@ -22,7 +22,7 @@ function announce(msg) {
   if (live) live.textContent = msg;
 }
 
-function showSavedEmoji() {
+export function showSavedEmoji() {
   const el = document.getElementById('emojiDisplay');
   if (el) {
     const emoji = localStorage.getItem('myEmoji');
@@ -30,11 +30,11 @@ function showSavedEmoji() {
   }
 }
 
-function storeLastLobby(id) {
+export function storeLastLobby(id) {
   localStorage.setItem('lastLobby', id);
 }
 
-function getLastLobby() {
+export function getLastLobby() {
   return localStorage.getItem('lastLobby');
 }
 

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -47,6 +47,35 @@ console.log(JSON.stringify(global.localStorage.data));
     data = json.loads(result.stdout.strip())
     assert data['dark'] == 'true'
 
+def test_store_and_get_last_lobby():
+    script = """
+global.document = { addEventListener(){}, body:{}, getElementById(){return null;} };
+global.localStorage = { data: {}, setItem(k,v){ this.data[k]=v; }, getItem(k){ return this.data[k]; } };
+const mod = await import('./frontend/landing.js');
+mod.storeLastLobby('ABC123');
+console.log(mod.getLastLobby());
+"""
+    result = subprocess.run(
+        ['node', '--input-type=module', '-e', script],
+        capture_output=True, text=True, check=True
+    )
+    assert result.stdout.strip() == 'ABC123'
+
+def test_show_saved_emoji_populates_element():
+    script = """
+const el = { textContent: '' };
+global.document = { addEventListener(){}, getElementById(id){ return id==='emojiDisplay' ? el : null; }, body:{} };
+global.localStorage = { data: { myEmoji: '🐶' }, getItem(k){ return this.data[k]; } };
+const mod = await import('./frontend/landing.js');
+mod.showSavedEmoji();
+console.log(el.textContent);
+"""
+    result = subprocess.run(
+        ['node', '--input-type=module', '-e', script],
+        capture_output=True, text=True, check=True
+    )
+    assert result.stdout.strip() == '🐶'
+
 def test_join_code_regex_present():
     text = Path('frontend/landing.js').read_text(encoding='utf-8')
     assert '^[A-Za-z0-9]{6}$' in text


### PR DESCRIPTION
## Summary
- mark local storage persistence task complete
- export landing page storage helpers
- add tests for last lobby and emoji display persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860bfc576d8832f80b84ef89c08fc1e