### PR TITLE
Implement landing page improvements

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,6 +39,7 @@ This file tracks outstanding tasks for "Wordle with Friends". Completed items ar
 - [x] Show feature highlight cards and a collapsible How-to-Play accordion.
 - [x] Persist dark mode, emoji, and last lobby code in `localStorage`.
 - [x] Write Jest DOM tests for rendering, validation, and preference storage.
+- [x] Implement How-to-Play accordion toggle and inline join-code validation.
 - [ ] Display lobby header with code, player count, and host controls.
 - [ ] Persist emoji across reloads and reclaim it via `POST /lobby/<id>/emoji`.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,6 +23,7 @@
       <form id="joinForm">
         <input id="joinCode" type="text" maxlength="6" autocomplete="off" aria-label="Lobby code">
         <button id="joinBtn" type="submit">Join Lobby</button>
+        <p id="joinError" class="error-text visually-hidden" role="alert"></p>
       </form>
       <button id="quickBtn" type="button">Quick Play</button>
       <button id="rejoinChip" type="button" hidden>Re-join</button>

--- a/frontend/landing.css
+++ b/frontend/landing.css
@@ -55,3 +55,17 @@ header {
   overflow: hidden;
   clip: rect(1px,1px,1px,1px);
 }
+
+/* Focus outlines for accessibility */
+button:focus,
+input:focus,
+a:focus {
+  outline: 2px solid var(--present-bg);
+  outline-offset: 2px;
+}
+
+.error-text {
+  color: var(--error-color);
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+}

--- a/frontend/landing.js
+++ b/frontend/landing.js
@@ -22,6 +22,20 @@ function announce(msg) {
   if (live) live.textContent = msg;
 }
 
+function showJoinError(msg) {
+  const err = document.getElementById('joinError');
+  if (err) {
+    err.textContent = msg;
+    err.classList.remove('visually-hidden');
+  }
+  announce(msg);
+}
+
+function clearJoinError() {
+  const err = document.getElementById('joinError');
+  if (err) err.classList.add('visually-hidden');
+}
+
 export function showSavedEmoji() {
   const el = document.getElementById('emojiDisplay');
   if (el) {
@@ -74,20 +88,42 @@ function initJoinForm() {
     rejoin.addEventListener('click', () => joinLobby(last));
   }
 
+  input.addEventListener('input', () => {
+    input.value = input.value.toUpperCase();
+    if (!/^[A-Za-z0-9]{0,6}$/.test(input.value)) {
+      showJoinError('Use letters and numbers only');
+    } else {
+      clearJoinError();
+    }
+  });
+
   form.addEventListener('submit', (e) => {
     e.preventDefault();
     const code = input.value.trim();
     if (/^[A-Za-z0-9]{6}$/.test(code)) {
+      clearJoinError();
       joinLobby(code);
     } else {
-      announce('Enter a valid 6 character code');
+      showJoinError('Enter a valid 6 character code');
     }
+  });
+}
+
+function initHowTo() {
+  const toggle = document.getElementById('howToggle');
+  const content = document.getElementById('howContent');
+  if (!toggle || !content) return;
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    content.hidden = expanded;
   });
 }
 
 export function init() {
   initDarkToggle();
   initJoinForm();
+  initHowTo();
   showSavedEmoji();
   document.getElementById('createBtn').addEventListener('click', createLobby);
   document.getElementById('quickBtn').addEventListener('click', quickPlay);


### PR DESCRIPTION
## Summary
- show inline join form errors
- add how-to-play accordion toggle and live validation
- improve focus outlines for accessibility
- update landing page TODOs

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860c212bce4832fa2cfdc638e9931d5