### PR TITLE
Add lobby header with player info

### DIFF
--- a/frontend/game.html
+++ b/frontend/game.html
@@ -79,6 +79,12 @@
       </form>
     </div>
 
+    <div id="lobbyHeader">
+      <span id="lobbyCode" aria-label="Lobby code"></span>
+      <span id="playerCount"></span>
+      <button id="copyLobbyLink" type="button" title="Copy lobby link">🔗</button>
+    </div>
+
     <div id="titleBar">
       <div id="resetWrapper">
         <button id="holdReset">

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -539,6 +539,18 @@
       text-align: center;
     }
 
+    #lobbyHeader {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 5px;
+      font-weight: 600;
+    }
+
+    #lobbyHeader button {
+      font-size: 0.9rem;
+    }
+
     /* ─── History Panel ─── */
     #historyBox {
       position: absolute;

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -69,6 +69,10 @@ const closeCallPopup = document.getElementById('closeCallPopup');
 const closeCallText = document.getElementById('closeCallText');
 const closeCallOk = document.getElementById('closeCallOk');
 const titleHintBadge = document.getElementById('titleHintBadge');
+const lobbyCodeEl = document.getElementById('lobbyCode');
+const playerCountEl = document.getElementById('playerCount');
+const copyLobbyLink = document.getElementById('copyLobbyLink');
+const lobbyHeader = document.getElementById('lobbyHeader');
 // Ensure the close-call popup starts hidden even if CSS hasn't loaded yet
 closeCallPopup.style.display = 'none';
 const chatNotify = document.getElementById('chatNotify');
@@ -77,6 +81,26 @@ const infoClose = document.getElementById('infoClose');
 const menuInfo = document.getElementById('menuInfo');
 
 let chatWiggleTimer = null;
+
+const LOBBY_CODE = (() => {
+  const m = window.location.pathname.match(/\/lobby\/([A-Za-z0-9]{6})/);
+  return m ? m[1] : null;
+})();
+
+if (lobbyCodeEl && LOBBY_CODE) {
+  lobbyCodeEl.textContent = LOBBY_CODE;
+} else if (lobbyHeader) {
+  lobbyHeader.style.display = 'none';
+}
+
+if (copyLobbyLink && LOBBY_CODE) {
+  copyLobbyLink.addEventListener('click', () => {
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      showMessage('Link copied!', { messageEl, messagePopup });
+      announce('Lobby link copied');
+    });
+  });
+}
 
 const FAST_INTERVAL = 2000;
 const SLOW_INTERVAL = 15000;
@@ -381,6 +405,9 @@ function applyState(state) {
   activeEmojis = state.active_emojis || [];
   leaderboard = state.leaderboard || [];
   dailyDoubleAvailable = !!state.daily_double_available;
+  if (playerCountEl) {
+    playerCountEl.textContent = `${activeEmojis.length} player${activeEmojis.length !== 1 ? 's' : ''}`;
+  }
   renderLeaderboard();
   updateHintBadge(titleHintBadge, dailyDoubleAvailable);
 

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -201,6 +201,17 @@ def test_hold_to_reset_elements_exist():
     assert '<span id="holdResetText"' in text
     assert '<span id="holdResetProgress"' in text
 
+def test_lobby_header_elements_exist():
+    text = GAME.read_text(encoding='utf-8')
+    assert '<div id="lobbyHeader"' in text
+    assert '<span id="lobbyCode"' in text
+    assert '<span id="playerCount"' in text
+    assert '<button id="copyLobbyLink"' in text
+
+def test_lobby_header_css_present():
+    css = read_css()
+    assert '#lobbyHeader {' in css
+
 
 def test_options_menu_has_dark_and_sound_buttons():
     text = GAME.read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary
- add a lobby header section showing lobby code and player count
- style lobby header in layout.css
- update main.js to populate and copy lobby link
- assert new header elements in frontend tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d5713e68832fb1f771125dc7d706