### PR TITLE
Add leave lobby button

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -40,7 +40,7 @@ This file tracks outstanding tasks for "Wordle with Friends". Completed items ar
 - [x] Persist dark mode, emoji, and last lobby code in `localStorage`.
 - [x] Write Jest DOM tests for rendering, validation, and preference storage.
 - [x] Implement How-to-Play accordion toggle and inline join-code validation.
-- [ ] Display lobby header with code, player count, and host controls.
+- [x] Display lobby header with code, player count, and host controls.
 - [x] Persist emoji across reloads and reclaim it via `POST /lobby/<id>/emoji`.
 
 ## Hosting & DevOps

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -82,7 +82,10 @@
     <div id="lobbyHeader">
       <span id="lobbyCode" aria-label="Lobby code"></span>
       <span id="playerCount"></span>
-      <button id="copyLobbyLink" type="button" title="Copy lobby link">🔗</button>
+      <div id="hostControls">
+        <button id="copyLobbyLink" type="button" title="Copy lobby link">🔗</button>
+        <button id="leaveLobby" type="button" title="Leave lobby">🚪</button>
+      </div>
     </div>
 
     <div id="titleBar">

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -551,6 +551,11 @@
       font-size: 0.9rem;
     }
 
+    #hostControls {
+      display: flex;
+      gap: 6px;
+    }
+
     /* ─── History Panel ─── */
     #historyBox {
       position: absolute;

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -72,6 +72,7 @@ const titleHintBadge = document.getElementById('titleHintBadge');
 const lobbyCodeEl = document.getElementById('lobbyCode');
 const playerCountEl = document.getElementById('playerCount');
 const copyLobbyLink = document.getElementById('copyLobbyLink');
+const leaveLobby = document.getElementById('leaveLobby');
 const lobbyHeader = document.getElementById('lobbyHeader');
 // Ensure the close-call popup starts hidden even if CSS hasn't loaded yet
 closeCallPopup.style.display = 'none';
@@ -99,6 +100,12 @@ if (copyLobbyLink && LOBBY_CODE) {
       showMessage('Link copied!', { messageEl, messagePopup });
       announce('Lobby link copied');
     });
+  });
+}
+
+if (leaveLobby && LOBBY_CODE) {
+  leaveLobby.addEventListener('click', () => {
+    window.location.href = '/';
   });
 }
 


### PR DESCRIPTION
## Summary
- add host controls section with Copy/Leave buttons in lobby header
- adjust CSS for new header controls
- wire up Leave Lobby button in JS
- mark lobby header task complete in TODO

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d7f7c4cc832f870b5c3ea404917d