### PR TITLE
Implement frontend build step for Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,15 @@ jobs:
         run: npm run cypress
         continue-on-error: true
 
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Copy build to backend
+        run: |
+          rm -rf backend/static/*
+          cp -r frontend/dist/* backend/static/
+
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID
         uses: aws-actions/configure-aws-credentials@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY backend/ backend/
+COPY backend/static/ backend/static/
 COPY sgb-words.txt .
 COPY offline_definitions.json .
 RUN pip install --no-cache-dir Flask Flask-Cors

--- a/README.md
+++ b/README.md
@@ -128,9 +128,13 @@ The home page served at `/` is the starting point for all players. It mirrors th
 
 ## Docker
 
-Build and run the Flask API using Docker:
+Build and run the Flask API using Docker. The image expects the compiled
+frontend assets under `backend/static`, so make sure to build the frontend
+first:
 
 ```bash
+cd frontend && npm run build && cd ..
+cp -r frontend/dist/* backend/static/
 docker build -t wwf-api .
 docker run -p 5001:5001 wwf-api
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@ This file tracks outstanding tasks for "Wordle with Friends". Completed items ar
 - [x] Move `package.json` and lockfile into `frontend/` and ensure Cypress and build tools are listed under dev dependencies. Run `npm ci` from that folder in the workflow.
 - [x] Create a minimal Cypress config that targets the Flask backend URL and add a smoke test verifying the page loads. Start the server in the workflow before launching Cypress.
 - [x] Harden the AWS deploy stage so it only runs on `main` when AWS secrets are present.
-- [ ] Execute the frontend build step prior to Docker and copy the `dist` output into the backend's static directory.
+- [x] Execute the frontend build step prior to Docker and copy the `dist` output into the backend's static directory.
 - [x] Add a `.dockerignore` excluding tests, workflow files, and `frontend/node_modules` to reduce image build context.
 - [x] Cache Python and Node dependencies in the workflow and temporarily allow the Cypress step to continue on error until the smoke test passes.
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -52,7 +52,8 @@ CORS(app)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s:%(message)s")
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-FRONTEND_DIR = BASE_DIR / "frontend"
+DEV_FRONTEND_DIR = BASE_DIR / "frontend"
+STATIC_DIR = BASE_DIR / "backend" / "static"
 WORDS_FILE = BASE_DIR / "sgb-words.txt"
 GAME_FILE = BASE_DIR / "game_persist.json"
 ANALYTICS_FILE = BASE_DIR / "analytics.log"
@@ -654,24 +655,28 @@ def reset_game():
 @app.route("/")
 def index():
     """Serve the landing page."""
-    return send_from_directory(str(FRONTEND_DIR), "index.html")
+    root = STATIC_DIR if (STATIC_DIR / "index.html").exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root), "index.html")
 
 @app.route("/game")
 def game_page():
     """Serve the main game client."""
-    return send_from_directory(str(FRONTEND_DIR), "game.html")
+    root = STATIC_DIR if (STATIC_DIR / "game.html").exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root), "game.html")
 
 # Serve static JavaScript modules
 @app.route('/static/js/<path:filename>')
 @app.route('/js/<path:filename>')
 def js_files(filename):
-    return send_from_directory(str(FRONTEND_DIR / 'static' / 'js'), filename)
+    root = STATIC_DIR if (STATIC_DIR / 'static' / 'js').exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root / 'static' / 'js'), filename)
 
 # Serve CSS assets
 @app.route('/static/css/<path:filename>')
 @app.route('/css/<path:filename>')
 def css_files(filename):
-    return send_from_directory(str(FRONTEND_DIR / 'static' / 'css'), filename)
+    root = STATIC_DIR if (STATIC_DIR / 'static' / 'css').exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root / 'static' / 'css'), filename)
 
 if __name__ == "__main__":
     load_data()


### PR DESCRIPTION
## Summary
- serve built assets when available
- copy static files into Docker image
- build frontend before packaging in the CI pipeline
- document build step in README
- mark TODO as complete

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686167f80088832f88b9fc8857d226c2