### PR TITLE
Implement lobby-ready game state

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@ This file tracks outstanding tasks for "Wordle with Friends". Completed items ar
 
 ## Lobby System & API
 
-- [ ] Convert global game state to a per-lobby dictionary keyed by six-character lobby codes.
+ - [x] Convert global game state to a per-lobby dictionary keyed by six-character lobby codes.
 - [ ] Implement the `/lobby` route family: create, state, emoji, guess, reset, stream, and lobby list.
 - [ ] Enforce lobby lifecycle (waiting → active → finished) and purge idle or finished lobbies after 30 minutes.
 - [ ] Require a `host_token` for privileged actions and rate-limit lobby creation.

--- a/backend/server.py
+++ b/backend/server.py
@@ -38,6 +38,7 @@ else:
     requests = _requests
 import logging
 import re
+from dataclasses import dataclass, field
 
 CLOSE_CALL_WINDOW = 2.0  # seconds
 import html
@@ -70,30 +71,40 @@ SCRABBLE_SCORES = {
     **{l: 10 for l in "qz"},
 }
 
+
 # ---- Globals ----
 WORDS = []
-target_word = ""
-guesses = []
-is_over = False
-winner_emoji = None
 
-leaderboard = {}      # emoji: {ip, score, used_yellow, used_green, last_active}
-ip_to_emoji = {}      # ip: emoji
-found_greens = set()  # all letters found as green by anyone this game
-found_yellows = set() # all letters found as yellow by anyone this game
-past_games = []       # list of finished games’ guess lists
-definition = None     # definition for the last solved word
-last_word = None      # last completed word
-last_definition = None  # definition of last completed word
-win_timestamp = None   # timestamp when the winning guess was submitted
-chat_messages = []     # list of chat messages
-listeners = set()      # SSE client queues
+@dataclass
+class GameState:
+    leaderboard: dict = field(default_factory=dict)
+    ip_to_emoji: dict = field(default_factory=dict)
+    winner_emoji: str | None = None
+    target_word: str = ""
+    guesses: list = field(default_factory=list)
+    is_over: bool = False
+    found_greens: set = field(default_factory=set)
+    found_yellows: set = field(default_factory=set)
+    past_games: list = field(default_factory=list)
+    definition: str | None = None
+    last_word: str | None = None
+    last_definition: str | None = None
+    win_timestamp: float | None = None
+    chat_messages: list = field(default_factory=list)
+    listeners: set = field(default_factory=set)
+    daily_double_index: int | None = None
+    daily_double_winners: set = field(default_factory=set)
+    daily_double_pending: dict = field(default_factory=dict)
+
+
 emoji_lock = threading.Lock()  # guard emoji selection operations
 
-# Daily Double state
-daily_double_index = None  # board tile index (0-based) containing the bonus
-daily_double_winners = set()  # emojis that triggered the bonus
-daily_double_pending = {}  # emoji -> row index eligible for hint selection
+# Lobby dictionary keyed by lobby code
+LOBBIES: dict[str, GameState] = {}
+
+# Current active lobby used by legacy routes
+DEFAULT_LOBBY = "DEFAULT"
+current_state: GameState = LOBBIES.setdefault(DEFAULT_LOBBY, GameState())
 
 
 def sanitize_definition(text: str) -> str:
@@ -103,59 +114,61 @@ def sanitize_definition(text: str) -> str:
     return " ".join(text.split())
 
 
-def _reset_state() -> None:
+def _reset_state(s: GameState | None = None) -> GameState:
     """Initialize all persistent in-memory structures to defaults."""
-    leaderboard.clear()
-    ip_to_emoji.clear()
-    global winner_emoji, target_word, is_over, definition
-    global last_word, last_definition, win_timestamp
-    global daily_double_index, daily_double_winners, daily_double_pending
-    winner_emoji = None
-    target_word = ""
-    guesses.clear()
-    is_over = False
-    found_greens.clear()
-    found_yellows.clear()
-    past_games.clear()
-    definition = None
-    last_word = None
-    last_definition = None
-    win_timestamp = None
-    chat_messages.clear()
-    daily_double_index = None
-    daily_double_winners.clear()
-    daily_double_pending.clear()
+    if s is None:
+        s = GameState()
+    else:
+        s.leaderboard.clear()
+        s.ip_to_emoji.clear()
+        s.guesses.clear()
+        s.found_greens.clear()
+        s.found_yellows.clear()
+        s.past_games.clear()
+        s.chat_messages.clear()
+        s.daily_double_winners.clear()
+        s.daily_double_pending.clear()
+    s.winner_emoji = None
+    s.target_word = ""
+    s.is_over = False
+    s.definition = None
+    s.last_word = None
+    s.last_definition = None
+    s.win_timestamp = None
+    s.daily_double_index = None
+    return s
 
 
-def save_data():
+def save_data(s: GameState | None = None):
+    if s is None:
+        s = current_state
     data = {
-        "leaderboard": leaderboard,
-        "ip_to_emoji": ip_to_emoji,
-        "winner_emoji": winner_emoji,
-        "target_word": target_word,
-        "guesses": guesses,
-        "is_over": is_over,
-        "found_greens": list(found_greens),
-        "found_yellows": list(found_yellows),
-        "past_games": past_games,
-        "definition": definition,
-        "last_word": last_word,
-        "last_definition": last_definition,
-        "win_timestamp": win_timestamp,
-        "chat_messages": chat_messages,
-        "daily_double_index": daily_double_index,
-        "daily_double_winners": list(daily_double_winners),
-        "daily_double_pending": daily_double_pending
+        "leaderboard": s.leaderboard,
+        "ip_to_emoji": s.ip_to_emoji,
+        "winner_emoji": s.winner_emoji,
+        "target_word": s.target_word,
+        "guesses": s.guesses,
+        "is_over": s.is_over,
+        "found_greens": list(s.found_greens),
+        "found_yellows": list(s.found_yellows),
+        "past_games": s.past_games,
+        "definition": s.definition,
+        "last_word": s.last_word,
+        "last_definition": s.last_definition,
+        "win_timestamp": s.win_timestamp,
+        "chat_messages": s.chat_messages,
+        "daily_double_index": s.daily_double_index,
+        "daily_double_winners": list(s.daily_double_winners),
+        "daily_double_pending": s.daily_double_pending,
     }
     with open(GAME_FILE, "w") as f:
         json.dump(data, f)
 
 
-def load_data():
-    global WORDS, leaderboard, ip_to_emoji, winner_emoji
-    global target_word, guesses, is_over, found_greens, found_yellows, past_games, definition
-    global last_word, last_definition, win_timestamp, chat_messages
-    global daily_double_index, daily_double_winners, daily_double_pending
+def load_data(s: GameState | None = None):
+    global WORDS, current_state
+    if s is None:
+        s = current_state
 
     # Load word list
     with open(WORDS_FILE) as f:
@@ -165,44 +178,44 @@ def load_data():
         with open(GAME_FILE) as f:
             try:
                 data = json.load(f)
-                leaderboard   = data.get("leaderboard", {})
-                ip_to_emoji   = data.get("ip_to_emoji", {})
-                winner_emoji  = data.get("winner_emoji")
-                target_word   = data.get("target_word", "")
-                guesses[:]    = data.get("guesses", [])
-                is_over       = data.get("is_over", False)
-                found_greens  = set(data.get("found_greens", []))
-                found_yellows = set(data.get("found_yellows", []))
-                past_games[:] = data.get("past_games", [])
-                definition    = data.get("definition")
-                last_word     = data.get("last_word")
-                last_definition = data.get("last_definition")
-                win_timestamp = data.get("win_timestamp")
-                chat_messages[:] = data.get("chat_messages", [])
-                daily_double_index = data.get("daily_double_index")
-                daily_double_winners = set(data.get("daily_double_winners", []))
-                daily_double_pending = data.get("daily_double_pending", {})
+                s.leaderboard   = data.get("leaderboard", {})
+                s.ip_to_emoji   = data.get("ip_to_emoji", {})
+                s.winner_emoji  = data.get("winner_emoji")
+                s.target_word   = data.get("target_word", "")
+                s.guesses[:]    = data.get("guesses", [])
+                s.is_over       = data.get("is_over", False)
+                s.found_greens  = set(data.get("found_greens", []))
+                s.found_yellows = set(data.get("found_yellows", []))
+                s.past_games[:] = data.get("past_games", [])
+                s.definition    = data.get("definition")
+                s.last_word     = data.get("last_word")
+                s.last_definition = data.get("last_definition")
+                s.win_timestamp = data.get("win_timestamp")
+                s.chat_messages[:] = data.get("chat_messages", [])
+                s.daily_double_index = data.get("daily_double_index")
+                s.daily_double_winners = set(data.get("daily_double_winners", []))
+                s.daily_double_pending = data.get("daily_double_pending", {})
             except Exception:
-                _reset_state()
+                _reset_state(s)
     else:
-        _reset_state()
+        _reset_state(s)
 
 # ---- Game Logic ----
-def pick_new_word():
-    """Choose a new target word and reset all in-memory game state."""
-    global target_word, guesses, is_over, winner_emoji, found_greens, found_yellows, definition, win_timestamp
-    global daily_double_index, daily_double_winners, daily_double_pending
-    target_word = random.choice(WORDS)
-    guesses.clear()
-    is_over = False
-    winner_emoji = None
-    found_greens = set()
-    found_yellows = set()
-    definition = None
-    win_timestamp = None
-    daily_double_index = random.randint(0, (MAX_ROWS - 1) * 5 - 1)
-    daily_double_winners.clear()
-    daily_double_pending.clear()
+def pick_new_word(s: GameState | None = None):
+    """Choose a new target word and reset all in-memory game current_state."""
+    if s is None:
+        s = current_state
+    s.target_word = random.choice(WORDS)
+    s.guesses.clear()
+    s.is_over = False
+    s.winner_emoji = None
+    s.found_greens = set()
+    s.found_yellows = set()
+    s.definition = None
+    s.win_timestamp = None
+    s.daily_double_index = random.randint(0, (MAX_ROWS - 1) * 5 - 1)
+    s.daily_double_winners.clear()
+    s.daily_double_pending.clear()
 
 def fetch_definition(word):
     """Look up a word's definition online with an offline JSON fallback."""
@@ -249,22 +262,23 @@ def fetch_definition(word):
     return None
 
 
-def _definition_worker(word: str) -> None:
+def _definition_worker(word: str, s: GameState) -> None:
     """Background task to fetch a word's definition and persist it."""
-    global definition, last_word, last_definition
-    definition = fetch_definition(word)
+    s.definition = fetch_definition(word)
     logging.info(
-        f"Definition lookup complete for '{word}': {definition or 'None'}"
+        f"Definition lookup complete for '{word}': {s.definition or 'None'}"
     )
-    last_word = word
-    last_definition = definition
-    save_data()
+    s.last_word = word
+    s.last_definition = s.definition
+    save_data(s)
     broadcast_state()
 
 
-def start_definition_lookup(word: str) -> threading.Thread:
+def start_definition_lookup(word: str, s: GameState | None = None) -> threading.Thread:
     """Start asynchronous definition lookup for the solved word."""
-    t = threading.Thread(target=_definition_worker, args=(word,))
+    if s is None:
+        s = current_state
+    t = threading.Thread(target=_definition_worker, args=(word, s))
     t.daemon = True
     t.start()
     return t
@@ -291,11 +305,13 @@ def result_for_guess(guess, target):
             target_letters[target_letters.index(guess[i])] = None
     return result
 
-def get_required_letters_and_positions():
+def get_required_letters_and_positions(s: GameState | None = None):
     """Aggregate hard mode constraints from prior guesses."""
+    if s is None:
+        s = current_state
     required_letters = set()
     green_positions = {}
-    for g in guesses:
+    for g in s.guesses:
         for i, res in enumerate(g["result"]):
             if res == "correct":
                 required_letters.add(g["guess"][i])
@@ -304,9 +320,11 @@ def get_required_letters_and_positions():
                 required_letters.add(g["guess"][i])
     return required_letters, green_positions
 
-def validate_hard_mode(guess):
+def validate_hard_mode(guess, s: GameState | None = None):
     """Check a guess against hard mode constraints."""
-    required_letters, green_positions = get_required_letters_and_positions()
+    if s is None:
+        s = current_state
+    required_letters, green_positions = get_required_letters_and_positions(s)
     for idx, ch in green_positions.items():
         if guess[idx] != ch:
             return False, f"Letter {ch.upper()} must be in position {idx+1}."
@@ -316,51 +334,55 @@ def validate_hard_mode(guess):
             return False, f"Guess must contain letter(s): {', '.join(m.upper() for m in missing)}."
     return True, ""
 
-def build_state_payload(emoji: str | None = None):
-    """Assemble the full game state dictionary returned to clients.
+def build_state_payload(emoji: str | None = None, s: GameState | None = None):
+    """Assemble the full game current_state dictionary returned to clients.
 
     When ``emoji`` is provided, include a ``daily_double_available`` boolean
     indicating whether that player currently has an unused hint.
     """
+    if s is None:
+        s = current_state
     lb = [
         {
             "emoji": emoji,
-            "score": leaderboard[emoji]["score"],
-            "last_active": leaderboard[emoji].get("last_active", 0),
+            "score": s.leaderboard[emoji]["score"],
+            "last_active": s.leaderboard[emoji].get("last_active", 0),
         }
-        for emoji in leaderboard
+        for emoji in s.leaderboard
     ]
     lb.sort(key=lambda e: e["score"], reverse=True)
 
     payload = {
-        "guesses": guesses,
-        "target_word": target_word if is_over else None,
-        "is_over": is_over,
+        "guesses": s.guesses,
+        "target_word": s.target_word if s.is_over else None,
+        "is_over": s.is_over,
         "leaderboard": lb,
-        "active_emojis": list(leaderboard.keys()),
-        "winner_emoji": winner_emoji,
+        "active_emojis": list(s.leaderboard.keys()),
+        "winner_emoji": s.winner_emoji,
         "max_rows": MAX_ROWS,
-        "past_games": past_games,
-        "definition": definition if is_over else None,
-        "last_word": last_word,
-        "last_definition": last_definition,
-        "chat_messages": chat_messages,
+        "past_games": s.past_games,
+        "definition": s.definition if s.is_over else None,
+        "last_word": s.last_word,
+        "last_definition": s.last_definition,
+        "chat_messages": s.chat_messages,
     }
 
     if emoji is not None:
-        payload["daily_double_available"] = emoji in daily_double_pending
+        payload["daily_double_available"] = emoji in s.daily_double_pending
 
     return payload
 
 
-def broadcast_state() -> None:
-    """Send the latest game state to all connected SSE clients."""
-    data = json.dumps(build_state_payload())
-    for q in list(listeners):
+def broadcast_state(s: GameState | None = None) -> None:
+    """Send the latest game current_state to all connected SSE clients."""
+    if s is None:
+        s = current_state
+    data = json.dumps(build_state_payload(s=s))
+    for q in list(s.listeners):
         try:
             q.put_nowait(data)
         except Exception:
-            listeners.discard(q)
+            s.listeners.discard(q)
 
 
 def log_daily_double_used(emoji: str, ip: str) -> None:
@@ -385,7 +407,7 @@ def stream():
     from flask import Response
 
     q = queue.Queue()
-    listeners.add(q)
+    current_state.listeners.add(q)
 
     def gen():
         try:
@@ -393,7 +415,7 @@ def stream():
                 data = q.get()
                 yield f"data: {data}\n\n"
         finally:
-            listeners.discard(q)
+            current_state.listeners.discard(q)
 
     return Response(gen(), mimetype="text/event-stream")
 
@@ -404,8 +426,8 @@ def state():
     if request.method == "POST":
         data = request.get_json(silent=True) or {}
         e = data.get("emoji")
-        if e and e in leaderboard:
-            leaderboard[e]["last_active"] = time.time()
+        if e and e in current_state.leaderboard:
+            current_state.leaderboard[e]["last_active"] = time.time()
             save_data()
             emoji = e
     else:
@@ -429,16 +451,16 @@ def set_emoji():
         return jsonify({"status": "error", "msg": "Invalid emoji."}), 400
 
     with emoji_lock:
-        if emoji in leaderboard and leaderboard[emoji]["ip"] != ip:
+        if emoji in current_state.leaderboard and current_state.leaderboard[emoji]["ip"] != ip:
             return (
                 jsonify({"status": "error", "msg": "That emoji is taken!"}),
                 409,
             )
 
-        prev_emoji = ip_to_emoji.get(ip)
+        prev_emoji = current_state.ip_to_emoji.get(ip)
         if prev_emoji and prev_emoji != emoji:
             # Move existing entry so score and history persist
-            entry = leaderboard.pop(
+            entry = current_state.leaderboard.pop(
                 prev_emoji,
                 {
                     "ip": ip,
@@ -448,9 +470,9 @@ def set_emoji():
                     "last_active": now,
                 },
             )
-            leaderboard[emoji] = entry
+            current_state.leaderboard[emoji] = entry
         else:
-            leaderboard.setdefault(
+            current_state.leaderboard.setdefault(
                 emoji,
                 {
                     "ip": ip,
@@ -460,18 +482,17 @@ def set_emoji():
                     "last_active": now,
                 },
             )
-        leaderboard[emoji]["ip"] = ip
-        leaderboard[emoji]["last_active"] = now
-        ip_to_emoji[ip] = emoji
+        current_state.leaderboard[emoji]["ip"] = ip
+        current_state.leaderboard[emoji]["last_active"] = now
+        current_state.ip_to_emoji[ip] = emoji
         save_data()
     broadcast_state()
     return jsonify({"status": "ok"})
 
 @app.route("/guess", methods=["POST"])
 def guess_word():
-    """Process a player's guess and update scores and game state."""
-    global is_over, winner_emoji, found_greens, found_yellows, definition
-    global last_word, last_definition, win_timestamp
+    """Process a player's guess and update scores and game current_state."""
+    global current_state
     data = request.json or {}
     guess = (data.get("guess") or "").strip().lower()
     # ▶ Prevent duplicates
@@ -480,45 +501,45 @@ def guess_word():
     points_delta = 0
     now = time.time()
 
-    if is_over:
+    if current_state.is_over:
         close_call = None
-        if guess == target_word and win_timestamp and emoji != winner_emoji:
-            diff = now - win_timestamp
+        if guess == current_state.target_word and current_state.win_timestamp and emoji != current_state.winner_emoji:
+            diff = now - current_state.win_timestamp
             if diff <= CLOSE_CALL_WINDOW:
-                close_call = {"delta_ms": int(diff * 1000), "winner": winner_emoji}
+                close_call = {"delta_ms": int(diff * 1000), "winner": current_state.winner_emoji}
         resp = {"status": "error", "msg": "Game is over. Please reset."}
         if close_call:
             resp["close_call"] = close_call
         return jsonify(resp), 403
     if not guess or len(guess) != 5 or guess not in WORDS:
         return jsonify({"status": "error", "msg": "Not a valid 5-letter word."}), 400
-    existing = [g["guess"] for g in guesses]
+    existing = [g["guess"] for g in current_state.guesses]
     if guess in existing:
         return jsonify(status="error", msg="You’ve already guessed that word."), 400
-    if emoji not in leaderboard or leaderboard[emoji]["ip"] != ip:
+    if emoji not in current_state.leaderboard or current_state.leaderboard[emoji]["ip"] != ip:
         return jsonify({"status": "error", "msg": "Please pick an emoji before playing."}), 403
 
-    leaderboard[emoji]["last_active"] = now
+    current_state.leaderboard[emoji]["last_active"] = now
 
     ok, msg = validate_hard_mode(guess)
     if not ok:
         return jsonify({"status": "error", "msg": msg}), 400
 
-    row_index = len(guesses)
-    result = result_for_guess(guess, target_word)
+    row_index = len(current_state.guesses)
+    result = result_for_guess(guess, current_state.target_word)
     new_entry = {"guess": guess, "result": result, "emoji": emoji, "ts": now}
-    already_guessed = any(g["guess"] == guess for g in guesses)
-    guesses.append(new_entry)
+    already_guessed = any(g["guess"] == guess for g in current_state.guesses)
+    current_state.guesses.append(new_entry)
 
     dd_award = False
     award_row = None
     award_col = None
-    if daily_double_index is not None:
-        dd_row = daily_double_index // 5
-        dd_col = daily_double_index % 5
-        if row_index == dd_row and result[dd_col] == "correct" and emoji not in daily_double_winners:
-            daily_double_winners.add(emoji)
-            daily_double_pending[emoji] = row_index + 1
+    if current_state.daily_double_index is not None:
+        dd_row = current_state.daily_double_index // 5
+        dd_col = current_state.daily_double_index % 5
+        if row_index == dd_row and result[dd_col] == "correct" and emoji not in current_state.daily_double_winners:
+            current_state.daily_double_winners.add(emoji)
+            current_state.daily_double_pending[emoji] = row_index + 1
             dd_award = True
             award_row = dd_row
             award_col = dd_col
@@ -530,47 +551,47 @@ def guess_word():
         value = SCRABBLE_SCORES.get(letter, 1)
         if r == "correct":
             # if we've never scored this letter as green *this game*:
-            if letter not in found_greens and letter not in global_found_this_turn:
-                if letter in found_yellows:
+            if letter not in current_state.found_greens and letter not in global_found_this_turn:
+                if letter in current_state.found_yellows:
                     # yellow previously discovered → award remaining half
                     points_delta += value / 2
-                    found_yellows.remove(letter)
+                    current_state.found_yellows.remove(letter)
                 else:
                     # brand-new green → full value
                     points_delta += value
-                found_greens.add(letter)
+                current_state.found_greens.add(letter)
                 global_found_this_turn.add(letter)
         elif r == "present":
-            if letter not in found_greens and letter not in found_yellows and letter not in global_found_this_turn:
+            if letter not in current_state.found_greens and letter not in current_state.found_yellows and letter not in global_found_this_turn:
                 # yellow discovery → half value
                 points_delta += value / 2
-                found_yellows.add(letter)
+                current_state.found_yellows.add(letter)
                 global_found_this_turn.add(letter)
 
     # Bonus for win, penalty for wrong final guess
-    won = guess == target_word
+    won = guess == current_state.target_word
     over = False
 
     if won:
         points_delta += 3
-        winner_emoji = emoji
-        is_over = True
+        current_state.winner_emoji = emoji
+        current_state.is_over = True
         over = True
-        win_timestamp = now
-    elif len(guesses) == MAX_ROWS:
-        is_over = True
+        current_state.win_timestamp = now
+    elif len(current_state.guesses) == MAX_ROWS:
+        current_state.is_over = True
         over = True
         if not won:
             points_delta -= 3  # Last guess, failed
 
     if over:
-        start_definition_lookup(target_word)
+        start_definition_lookup(current_state.target_word, current_state)
 
     # -1 penalty for duplicate guesses with no new yellows/greens
     if points_delta == 0 and not won and not over:
         points_delta -= 1
 
-    leaderboard[emoji]["score"] += points_delta
+    current_state.leaderboard[emoji]["score"] += points_delta
     save_data()
     # — attach this turn’s points so client can render a history
     new_entry["points"] = points_delta
@@ -585,7 +606,7 @@ def guess_word():
         "won": won,
         "over": over,
         "daily_double": dd_award,
-        "daily_double_available": emoji in daily_double_pending,
+        "daily_double_available": emoji in current_state.daily_double_pending,
     }
     if dd_award:
         resp["daily_double_tile"] = {"row": award_row, "col": award_col}
@@ -600,10 +621,10 @@ def select_hint():
     col = data.get("col")
     ip = get_client_ip()
 
-    if emoji not in leaderboard or leaderboard[emoji]["ip"] != ip:
+    if emoji not in current_state.leaderboard or current_state.leaderboard[emoji]["ip"] != ip:
         return jsonify({"status": "error", "msg": "Invalid player."}), 403
 
-    if emoji not in daily_double_pending:
+    if emoji not in current_state.daily_double_pending:
         return jsonify({"status": "error", "msg": "No hint available."}), 400
 
     try:
@@ -614,8 +635,8 @@ def select_hint():
     if not 0 <= col < 5:
         return jsonify({"status": "error", "msg": "Invalid column."}), 400
 
-    row = daily_double_pending.pop(emoji)
-    letter = target_word[col]
+    row = current_state.daily_double_pending.pop(emoji)
+    letter = current_state.target_word[col]
     save_data()
     log_daily_double_used(emoji, ip)
     return jsonify({
@@ -634,20 +655,20 @@ def chat():
         emoji = data.get("emoji")
         if not text:
             return jsonify({"status": "error", "msg": "Empty message."}), 400
-        if emoji not in leaderboard:
+        if emoji not in current_state.leaderboard:
             return jsonify({"status": "error", "msg": "Pick an emoji first."}), 400
-        chat_messages.append({"emoji": emoji, "text": text, "ts": time.time()})
+        current_state.chat_messages.append({"emoji": emoji, "text": text, "ts": time.time()})
         save_data()
         broadcast_state()
         return jsonify({"status": "ok"})
-    return jsonify({"messages": chat_messages})
+    return jsonify({"messages": current_state.chat_messages})
 
 @app.route("/reset", methods=["POST"])
 def reset_game():
     """Archive the current game and start a fresh one."""
     # Save the just-finished game into history
-    past_games.append(list(guesses))
-    pick_new_word()
+    current_state.past_games.append(list(current_state.guesses))
+    pick_new_word(current_state)
     save_data()
     broadcast_state()
     return jsonify({"status": "ok"})
@@ -680,7 +701,7 @@ def css_files(filename):
 
 if __name__ == "__main__":
     load_data()
-    if not target_word:
-        pick_new_word()
+    if not current_state.target_word:
+        pick_new_word(current_state)
         save_data()
     app.run(host='0.0.0.0', port=5001)


### PR DESCRIPTION
## Summary
- refactor backend to store game state in a `GameState` dataclass
- introduce a lobby dictionary and `current_state` for legacy routes
- update API code to reference the state object
- update unit tests for new structure
- mark lobby refactor item complete in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617af00e60832f83627e9a376025c4