### PR TITLE
Update Dockerfile to run via gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY backend/ backend/
 COPY backend/static/ backend/static/
 COPY sgb-words.txt .
 COPY offline_definitions.json .
-RUN pip install --no-cache-dir Flask Flask-Cors
+RUN pip install --no-cache-dir -r backend/requirements.txt
 ENV PYTHONUNBUFFERED=1
-CMD ["python", "backend/server.py"]
+EXPOSE 5000
+CMD ["gunicorn", "-k", "gevent", "--timeout", "0", "-b", "0.0.0.0:5000", "backend.server:app"]

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ first:
 cd frontend && npm run build && cd ..
 cp -r frontend/dist/* backend/static/
 docker build -t wwf-api .
-docker run -p 5001:5001 wwf-api
+docker run -p 5000:5000 wwf-api
 ```
 
-The container exposes port **5001** and serves the game API and static files.
+The container exposes port **5000** and serves the game API and static files.
 
 ## Continuous Integration
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ Flask-Cors
 pytest
 requests
 redis
+gunicorn


### PR DESCRIPTION
## Summary
- run the production image using gunicorn instead of `python backend/server.py`
- expose port 5000 from the container
- document the new port mapping
- include gunicorn in backend requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619c817154832f83bd228db0979261