### PR TITLE
Add deployment guide and repo practices

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -43,3 +43,5 @@ Responsive Layout
 Testing
 • Encourage writing and running tests for any new or modified logic.
 • Suggest unit tests for isolated functions and integration tests for game flow.
+• Branch names should follow the short `feat/*`, `fix/*`, or `docs/*` pattern.
+• Pull requests must pass Pytest, Cypress, and `terraform plan` status checks before merging to `main`.

--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -1,0 +1,31 @@
+# Deployment Guide
+
+This guide outlines the steps to deploy the Wordle With Friends infrastructure and API using Terraform and GitHub Actions.
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads.html) 1.4 or newer
+- AWS account with permissions to create S3, DynamoDB, ECS and related resources
+- Docker installed locally if building images manually
+- AWS CLI configured with your credentials
+
+## Bootstrap Steps
+
+1. **Remote State**
+   - Create an S3 bucket and DynamoDB table for Terraform state and locking.
+   - Update `infra/live/variables.tfvars` with the bucket name, region and table.
+   - Run `terraform init -backend-config="bucket=<state-bucket>" -backend-config="dynamodb_table=<lock-table>"` inside `infra/terraform`.
+
+2. **Initial Apply**
+   - Populate `infra/live/variables.tfvars` with the required variables such as `aws_region`, `frontend_bucket`, `domain`, `vpc_id`, `subnets`, `ecs_task_execution_role` and `api_image`.
+   - Execute `terraform plan -var-file=infra/live/variables.tfvars` and review the output.
+   - Apply with `terraform apply -var-file=infra/live/variables.tfvars`.
+
+3. **GitHub Secrets**
+   - Add the following repository secrets so the CI workflow can deploy:
+     `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ACCOUNT_ID`, `AWS_REGION`, `ECR_REPO`, `TF_VAR_domain` and `CF_DISTRIBUTION_ID`.
+
+4. **CI/CD**
+   - The workflow runs tests and `terraform plan` on every pull request. Deployments occur automatically when changes land on `main` and the required secrets are present.
+
+Refer to `infra/terraform/README.md` for details on the Terraform modules.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The mode updates automatically on window resize or device orientation changes.
 
 ## Landing Page
 
-The home page served at `/` is the starting point for all players. It mirrors the neumorphic style of the game board and stores your dark-mode setting, chosen emoji, and most recent lobby code in `localStorage`. See `LANDING_PAGE_REQUIREMENTS.md` for the full specification. Key pieces include:
+The home page served at `/` is the starting point for all players. It mirrors the neumorphic style of the game board and stores your dark-mode setting, chosen emoji, and most recent lobby code in `localStorage`. See [LANDING_PAGE_REQUIREMENTS.md](LANDING_PAGE_REQUIREMENTS.md) for the full specification. Key pieces include:
 
 - A sticky header with theme toggle plus Help and GitHub links.
 - A hero card with **Create Lobby**, **Join Lobby**, **Quick Play**, and a re-join chip when available.
@@ -160,3 +160,9 @@ a production deployment. These include an S3 bucket for the static frontend,
 CloudFront distribution with HTTPS via ACM, an Application Load Balancer, and an
 ECS Fargate service running the Flask API. Refer to the README in that directory
 for usage instructions.
+
+## Repository Practices
+
+- Branch names follow the short `feat/*`, `fix/*`, or `docs/*` pattern.
+- Pull requests must pass status checks for Pytest, Cypress, and `terraform plan` before merging to `main`.
+- See [DEPLOY_GUIDE.md](DEPLOY_GUIDE.md) for details on configuring deployment secrets and running Terraform.


### PR DESCRIPTION
## Summary
- link LANDING_PAGE_REQUIREMENTS in README
- document branch naming and required status checks
- add DEPLOY_GUIDE detailing Terraform bootstrap and secrets
- update AGENT instructions accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619d80e6c4832fbd6fce92bf567e26