### PR TITLE
Add Codex pipeline config

### DIFF
--- a/.codex.yaml
+++ b/.codex.yaml
@@ -1,0 +1,14 @@
+version: 1
+setup:
+  - apt-get update -qq
+  - >-
+    apt-get install -y xvfb libgtk-3-0 libgbm-dev libnss3 libxshmfence1 \
+    libasound2 libatk-bridge2.0-0 libdrm2 curl gconf-service
+  - curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs
+  - cd frontend && npm ci && npx cypress install && cd ..
+  - pip install -r backend/requirements.txt
+test:
+  - python -m pytest -q
+  - cd frontend && xvfb-run -a npx cypress run --browser electron --headless && cd ..
+env:
+  CYPRESS_CACHE_FOLDER: ".cache/Cypress"


### PR DESCRIPTION
## Summary
- add `.codex.yaml` with setup steps, test commands, and CYPRESS cache env

## Testing
- `python -m pytest -q`
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cypress)*
- `npx cypress install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cypress)*
- `terraform init` *(fails: terraform: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a32f5228832fb9c5fac259c59ddc