### PR TITLE
feat: validate lobby codes

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -91,6 +91,7 @@ SCRABBLE_SCORES = {
 LOBBY_TTL = 30 * 60  # 30 minutes
 LOBBY_CREATION_LIMIT = 5
 LOBBY_CREATION_WINDOW = 60  # seconds
+LOBBY_CODE_RE = re.compile(r"^[A-Za-z0-9]{6}$")
 
 
 # ---- Globals ----
@@ -154,6 +155,8 @@ def purge_lobbies() -> None:
 
 def _with_lobby(code: str, func):
     """Temporarily switch ``current_state`` to the lobby for ``code``."""
+    if not LOBBY_CODE_RE.fullmatch(code):
+        return jsonify({"status": "error", "msg": "Invalid lobby code"}), 400
     purge_lobbies()
     global current_state
     state = get_lobby(code)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -953,6 +953,16 @@ def test_lobby_create_rate_limit(server_env, monkeypatch):
     assert 'id' in resp2
 
 
+def test_lobby_code_validation(server_env):
+    server, request = server_env
+
+    bad = server.lobby_state('invalid!')
+    assert isinstance(bad, tuple)
+    data, status = bad
+    assert status == 400
+    assert data['status'] == 'error'
+
+
 def test_lobby_analytics_create_join_finish(tmp_path, server_env, monkeypatch):
     server, request = server_env
     log_file = tmp_path / 'analytics.log'


### PR DESCRIPTION
## Summary
- enforce lobby code format
- test invalid lobby codes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a73e1ecc832fb815f125493b116a