### PR TITLE
feat: periodic lobby purge

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -93,7 +93,7 @@ No outstanding tasks.
   - `GET /lobby/<id>/stream`
   - `GET /lobbies`
 - [ ] Scope SSE broadcasting to each lobby via `listeners[lobby_id]`.
-- [ ] Clean up idle lobbies every ten minutes when `last_active` is over thirty minutes old.
+ - [x] Clean up idle lobbies every ten minutes when `last_active` is over thirty minutes old.
 - [ ] Add middleware for rate limiting (max five lobby creations per IP per minute) and lobby id validation.
 - [ ] Toggle persistence: JSON file in single-instance mode, stubs for Redis or DynamoDB otherwise.
 - [ ] Add unit tests for all lobby service helpers.

--- a/backend/server.py
+++ b/backend/server.py
@@ -936,4 +936,15 @@ if __name__ == "__main__":
     if not current_state.target_word:
         pick_new_word(current_state)
         save_data()
+    # Launch a background thread that periodically purges idle lobbies
+    def _purge_loop() -> None:
+        while True:
+            time.sleep(600)
+            try:
+                purge_lobbies()
+            except Exception as e:  # pragma: no cover - best effort cleanup
+                logging.warning("Purge thread error: %s", e)
+
+    t = threading.Thread(target=_purge_loop, daemon=True)
+    t.start()
     app.run(host='0.0.0.0', port=5001)


### PR DESCRIPTION
## Summary
- run a background purge loop in the server to clean up idle lobbies every 10 minutes
- mark TODO complete for the lobby cleanup step

## Testing
- `python -m pytest -q`
- `xvfb-run -a npx cypress run --browser electron --headless` *(fails: cypress not installed due to network restrictions)*
- `terraform init -backend=false` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6861b63a5c78832fa527e0a0f5901f24