### PR TITLE
feat(frontend): add waiting overlay

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -99,18 +99,18 @@ No outstanding tasks.
 - [ ] Add unit tests for all lobby service helpers.
 
 ### Landing Page & Client Routing
-- [ ] Add `frontend/landing.html`, `landing.js` and `landing.css` implementing the hero panel and create/join flows.
+ - [x] Add `frontend/landing.html`, `landing.js` and `landing.css` implementing the hero panel and create/join flows.
 - [x] Provide a modal to copy the invite link and use the Web Share API on mobile if available.
 - [ ] Implement a lightweight hash router to swap between the landing page and lobby board.
-- [ ] Include a header bar inside the lobby view with lobby code, player count and host menu.
+ - [x] Include a header bar inside the lobby view with lobby code, player count and host menu.
 - [ ] Build a player sidebar component with emoji, score and AFK indicator plus kick controls.
-- [ ] Display a waiting-room overlay while the lobby state is `waiting`.
+ - [x] Display a waiting-room overlay while the lobby state is `waiting`.
 - [ ] Perform an accessibility pass covering focus management, ARIA labels and color contrast.
 
 ### Frontend Interaction with New API
-- [ ] Replace hard-coded `/state` and `/stream` calls with lobby-specific endpoints.
-- [ ] Hydrate the board via `GET /lobby/<id>/state` on load and subscribe to `/lobby/<id>/stream`.
-- [ ] Update emoji claim and rejoin logic to post to `/emoji` with the lobby id.
+ - [x] Replace hard-coded `/state` and `/stream` calls with lobby-specific endpoints.
+ - [x] Hydrate the board via `GET /lobby/<id>/state` on load and subscribe to `/lobby/<id>/stream`.
+ - [x] Update emoji claim and rejoin logic to post to `/emoji` with the lobby id.
 - [ ] Show toast notifications for full lobbies, kicks and expired sessions.
 
 ### Infrastructure & Terraform

--- a/backend/server.py
+++ b/backend/server.py
@@ -471,6 +471,7 @@ def build_state_payload(emoji: str | None = None, s: GameState | None = None):
         "active_emojis": list(s.leaderboard.keys()),
         "winner_emoji": s.winner_emoji,
         "max_rows": MAX_ROWS,
+        "phase": s.phase,
         "past_games": s.past_games,
         "definition": s.definition if s.is_over else None,
         "last_word": s.last_word,

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -100,6 +100,8 @@
       </div>
     </div>
 
+    <div id="waitingOverlay" role="alert" aria-live="polite">Waiting for players…</div>
+
     <div id="titleBar">
       <div id="resetWrapper">
         <button id="holdReset">

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -291,6 +291,7 @@
 /* Initial layout states */
 #emojiModal,
 #closeCallPopup,
+#waitingOverlay,
 #infoPopup,
 #optionsMenu,
 #shareModal {
@@ -1226,6 +1227,21 @@
       display: flex;
       align-items: center;
       justify-content: center;
+    }
+
+    #waitingOverlay {
+      background: rgba(0, 0, 0, 0.33);
+      position: fixed;
+      z-index: 100;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--text-color);
+      font-size: 1.2rem;
     }
 
     #closeCallBox {

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -74,6 +74,7 @@ const playerCountEl = document.getElementById('playerCount');
 const copyLobbyLink = document.getElementById('copyLobbyLink');
 const leaveLobby = document.getElementById('leaveLobby');
 const lobbyHeader = document.getElementById('lobbyHeader');
+const waitingOverlay = document.getElementById('waitingOverlay');
 // Ensure the close-call popup starts hidden even if CSS hasn't loaded yet
 closeCallPopup.style.display = 'none';
 const chatNotify = document.getElementById('chatNotify');
@@ -439,6 +440,9 @@ function applyState(state) {
   dailyDoubleAvailable = !!state.daily_double_available;
   if (playerCountEl) {
     playerCountEl.textContent = `${activeEmojis.length} player${activeEmojis.length !== 1 ? 's' : ''}`;
+  }
+  if (waitingOverlay) {
+    waitingOverlay.style.display = state.phase === 'waiting' ? 'flex' : 'none';
   }
   renderLeaderboard();
   updateHintBadge(titleHintBadge, dailyDoubleAvailable);

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -259,6 +259,11 @@ def test_message_containers_exist():
     assert '<div id="ariaLive"' in text
 
 
+def test_waiting_overlay_present():
+    text = GAME.read_text(encoding='utf-8')
+    assert '<div id="waitingOverlay"' in text
+
+
 def test_show_message_desktop_behavior():
     script = """
 import { showMessage } from './frontend/static/js/utils.js';


### PR DESCRIPTION
## Summary
- expose lobby phase in server state
- show waiting-room overlay when lobby is waiting
- mark completed frontend tasks in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ba355f90832f85754d37a016e31a