### PR TITLE
feat/serve-lobby-path

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -918,6 +918,13 @@ def game_page():
     root = STATIC_DIR if (STATIC_DIR / "game.html").exists() else DEV_FRONTEND_DIR
     return send_from_directory(str(root), "game.html")
 
+
+@app.route("/lobby/<code>")
+def lobby_page(code: str):
+    """Serve the game client for a specific lobby."""
+    root = STATIC_DIR if (STATIC_DIR / "game.html").exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root), "game.html")
+
 # Serve static JavaScript modules
 @app.route('/static/js/<path:filename>')
 @app.route('/js/<path:filename>')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1033,3 +1033,9 @@ def test_cleanup_endpoint_triggers_purge(monkeypatch, server_env):
     resp = server.cleanup_lobbies()
     assert resp['status'] == 'ok'
     assert called.get('yes')
+
+
+def test_lobby_page_serves_game_html(server_env):
+    server, _ = server_env
+    path = server.lobby_page('ABC123')
+    assert path.endswith('game.html')


### PR DESCRIPTION
## Summary
- serve the game client from `/lobby/<code>`
- test new lobby page route

## Testing
- `pytest -q`
- `npx cypress run --browser electron --headless` *(fails: Need to install cypress)*
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861bc89acdc832fbca2349bc775a2d2