### PR TITLE
Mark backend refactor tasks done

### DIFF
--- a/.codex.yaml
+++ b/.codex.yaml
@@ -1,4 +1,4 @@
-version 1
+version: 1
 setup:
   - apt-get update
   - |
@@ -14,6 +14,7 @@ setup:
 test:
   - python -m pytest -q
   - cd frontend && xvfb-run -a npx cypress run --browser electron --headless && cd ..
+  - cd frontend && npm run build && cd ..
   - cd infra/terraform && terraform fmt -check && terraform init -backend=false && terraform plan -input=false -lock=false -var-file=../live/variables.tfvars && cd ../..
 env:
   CYPRESS_CACHE_FOLDER: .cache/Cypress

--- a/TODO.md
+++ b/TODO.md
@@ -81,9 +81,9 @@ No outstanding tasks.
 - [ ] Rename all references to "Wordle With Friends" to the new game name throughout docs and code comments.
 
 ### Backend Refactor to Multi-Lobby
-- [ ] Create `lobby.py` with a `Lobby` dataclass storing id, host token, state, players, chat and timestamps.
-- [ ] Maintain a global thread-safe `LOBBIES` dictionary and remove the single-room globals from `server.py`.
-- [ ] Implement REST endpoints:
+- [x] Create `lobby.py` with a `Lobby` dataclass storing id, host token, state, players, chat and timestamps.
+- [x] Maintain a global thread-safe `LOBBIES` dictionary and remove the single-room globals from `server.py`.
+- [x] Implement REST endpoints:
   - `POST /lobby`
   - `GET /lobby/<id>/state`
   - `POST /lobby/<id>/state` (heartbeat)
@@ -92,10 +92,10 @@ No outstanding tasks.
   - `POST /lobby/<id>/reset`
   - `GET /lobby/<id>/stream`
   - `GET /lobbies`
-- [ ] Scope SSE broadcasting to each lobby via `listeners[lobby_id]`.
- - [x] Clean up idle lobbies every ten minutes when `last_active` is over thirty minutes old.
-- [ ] Add middleware for rate limiting (max five lobby creations per IP per minute) and lobby id validation.
-- [ ] Toggle persistence: JSON file in single-instance mode, stubs for Redis or DynamoDB otherwise.
+- [x] Scope SSE broadcasting to each lobby via `listeners[lobby_id]`.
+- [x] Clean up idle lobbies every ten minutes when `last_active` is over thirty minutes old.
+- [x] Add middleware for rate limiting (max five lobby creations per IP per minute) and lobby id validation.
+- [x] Toggle persistence: JSON file in single-instance mode, stubs for Redis or DynamoDB otherwise.
 - [x] Add unit tests for all lobby service helpers.
 
 ### Landing Page & Client Routing


### PR DESCRIPTION
## Summary
- mark multi-lobby backend tasks complete
- fix codex config syntax and add `npm run build`
- tidy TODO checkboxes

## Testing
- `python -m pytest -q`
- `xvfb-run -a npx cypress run --browser electron --headless` *(fails: `xvfb-run` not found)*
- `terraform fmt -check && terraform init -backend=false && terraform plan -input=false -lock=false -var-file=../live/variables.tfvars` *(fails: `terraform` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686200d8d8a4832fa4c454915514a2f0