### PR TITLE
Implement hash router and player sidebar

### DIFF
--- a/frontend/game.html
+++ b/frontend/game.html
@@ -90,6 +90,10 @@
         <button id="chatSend" type="submit">Send</button>
       </form>
     </div>
+    <div id="playerSidebar" role="dialog" aria-label="Players">
+      <button id="playerClose" class="close-btn" type="button">✖</button>
+      <ul id="playerList"></ul>
+    </div>
 
     <div id="lobbyHeader">
       <span id="lobbyCode" aria-label="Lobby code"></span>
@@ -97,6 +101,7 @@
       <div id="hostControls">
         <button id="copyLobbyLink" type="button" title="Copy lobby link">🔗</button>
         <button id="leaveLobby" type="button" title="Leave lobby">🚪</button>
+        <button id="playerToggle" type="button" title="Player list">👥</button>
       </div>
     </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="landing.css">
 </head>
 <body>
+<div id="landingView">
   <header id="mainHeader">
     <h1 id="logo">WWF</h1>
     <span id="emojiDisplay" aria-label="Selected emoji"></span>
@@ -44,6 +45,8 @@
     <p>Not affiliated with Wordle. <a href="LICENSE">MIT License</a></p>
   </footer>
   <div id="ariaLive" aria-live="polite" class="visually-hidden"></div>
+</div>
+<div id="lobbyView" hidden></div>
   <script type="module" src="landing.js"></script>
 </body>
 </html>

--- a/frontend/landing.css
+++ b/frontend/landing.css
@@ -69,3 +69,9 @@ a:focus {
   margin: 0.25rem 0 0;
   font-size: 0.9rem;
 }
+
+#lobbyView iframe {
+  width: 100%;
+  height: 100vh;
+  border: none;
+}

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -553,6 +553,10 @@
       font-size: 0.9rem;
     }
 
+    #playerToggle {
+      margin-left: 4px;
+    }
+
     #hostControls {
       display: flex;
       gap: 6px;
@@ -1348,10 +1352,45 @@
       -ms-user-select: none;
     }
 
-    #definitionBox,
-    #chatBox {
-      user-select: text;
-      -webkit-user-select: text;
-      -moz-user-select: text;
-      -ms-user-select: text;
-    }
+#definitionBox,
+#chatBox {
+  user-select: text;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+}
+
+#playerSidebar {
+  position: fixed;
+  top: 50%;
+  left: 0;
+  transform: translate(-100%, -50%);
+  background: var(--bg-color);
+  box-shadow: 2px 2px 8px var(--shadow-color-dark),
+              -2px -2px 8px var(--shadow-color-light);
+  padding: 8px;
+  border-radius: 8px;
+  max-height: 90vh;
+  overflow-y: auto;
+  z-index: 60;
+  pointer-events: none;
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+body.players-open #playerSidebar {
+  transform: translate(0, -50%);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.player-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 4px 0;
+}
+
+.player-row.inactive {
+  opacity: 0.5;
+}

--- a/frontend/static/css/theme.css
+++ b/frontend/static/css/theme.css
@@ -89,3 +89,22 @@ body {
   white-space: nowrap;
   border: 0;
 }
+
+/* Neumorphic base style for buttons */
+button {
+  border: none;
+  border-radius: 8px;
+  padding: 0.4rem 0.8rem;
+  background: var(--bg-color);
+  color: var(--text-color);
+  box-shadow: 3px 3px 6px var(--shadow-color-dark),
+              -3px -3px 6px var(--shadow-color-light);
+  cursor: pointer;
+  transition: box-shadow 0.2s, transform 0.1s;
+}
+
+button:active {
+  box-shadow: inset 2px 2px 4px var(--inset-shadow-dark),
+              inset -2px -2px 4px var(--inset-shadow-light);
+  transform: translateY(1px);
+}

--- a/frontend/static/js/api.js
+++ b/frontend/static/js/api.js
@@ -38,9 +38,14 @@ export async function sendGuess(guess, emoji, lobbyId) {
 /**
  * Force a new round by resetting the current game.
  */
-export async function resetGame(lobbyId) {
+export async function resetGame(lobbyId, hostToken) {
   const url = lobbyId ? `/lobby/${lobbyId}/reset` : '/reset';
-  const r = await fetch(url, { method: 'POST' });
+  const body = hostToken ? { host_token: hostToken } : {};
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
   return r.json();
 }
 
@@ -117,6 +122,16 @@ export async function requestHint(col, emoji, lobbyId) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ col, emoji })
+  });
+  return r.json();
+}
+
+export async function kickPlayerRequest(lobbyId, emoji, hostToken) {
+  const url = `/lobby/${lobbyId}/kick`;
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ emoji, host_token: hostToken })
   });
   return r.json();
 }


### PR DESCRIPTION
## Summary
- add neumorphic button styles
- implement hash-based router that swaps landing and lobby views
- store host token and use it for reset and kick actions
- add player sidebar with kick controls
- style sidebar with neumorphic design

## Testing
- `python -m pytest -q`
- `xvfb-run -a npx cypress run --browser electron --headless` *(fails: module is not defined)*
- `npm run build` *(fails: vite not found)*
- `terraform fmt -check && terraform init -backend=false && terraform plan -input=false -lock=false -var-file=../live/variables.tfvars` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863255a7384832f8fd80ff759559334