### PR TITLE
chore: add terraform ignore config

### DIFF
--- a/infra/terraform/.terraformignore
+++ b/infra/terraform/.terraformignore
@@ -1,0 +1,9 @@
+# Ignore local Terraform working directory
+.terraform/
+
+# Ignore Terraform state files
+*.tfstate
+*.tfstate.*
+
+# Ignore plan files
+*.tfplan


### PR DESCRIPTION
## Summary
- keep terraform cache & state files out of packaging

## Testing
- `python -m pytest -v`
- `npm --prefix frontend run cypress` *(fails: support file missing)*
- `terraform -chdir=infra/terraform init` *(fails: requires S3 bucket)*
- `terraform -chdir=infra/terraform plan -input=false` *(fails: backend init required)*

------
https://chatgpt.com/codex/tasks/task_e_68634402d4dc832fa6608ab77599be0f