### PR TITLE
Fix definition broadcast for lobbies

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -388,7 +388,7 @@ def _definition_worker(word: str, s: GameState) -> None:
     s.last_word = word
     s.last_definition = s.definition
     save_data(s)
-    broadcast_state()
+    broadcast_state(s)
 
 
 def start_definition_lookup(word: str, s: GameState | None = None) -> threading.Thread:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -485,6 +485,22 @@ def test_fetch_definition_offline_fallback(monkeypatch, server_env):
     assert definition == 'a large bird or lifting machine'
 
 
+def test_definition_worker_broadcasts_specific_state(monkeypatch, server_env):
+    server, _ = server_env
+
+    captured = {}
+
+    def fake_broadcast(s=None):
+        captured['state'] = s
+
+    monkeypatch.setattr(server, 'broadcast_state', fake_broadcast)
+
+    state = server.GameState()
+    server._definition_worker('apple', state)
+
+    assert captured['state'] is state
+
+
 def test_definition_available_after_game_over(monkeypatch, server_env):
     server, request = server_env
 


### PR DESCRIPTION
## Summary
- ensure the async definition lookup broadcasts the correct lobby state
- test `_definition_worker` to verify it uses the provided state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68634fc7032c832f86e1a1cfcc70a2e9