### PR TITLE
fix(reset): reset global state by default

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -179,9 +179,15 @@ def sanitize_definition(text: str) -> str:
 
 
 def _reset_state(s: GameState | None = None) -> GameState:
-    """Initialize all persistent in-memory structures to defaults."""
+    """Initialize all persistent in-memory structures to defaults.
+
+    When ``s`` is ``None``, reset :data:`current_state` in place rather than
+    creating a new ``GameState``.  The previous behaviour of returning a brand
+    new instance made it easy to accidentally discard the reset object and
+    leave the global state unchanged.
+    """
     if s is None:
-        s = GameState()
+        s = current_state
     else:
         host_token = s.host_token
         s.leaderboard.clear()


### PR DESCRIPTION
## Summary
- make `_reset_state()` operate on `current_state` when no argument is given
- document the new behaviour

## Testing
- `python -m pytest -q`
- `npm run cypress` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863c64dbbc0832fadf11fb739576852