### PR TITLE
fix/frontend-share-link-style

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -1321,6 +1321,14 @@
     #shareLink {
       width: 100%;
       margin-top: 8px;
+      border: none;
+      padding: 10px;
+      font-size: 16px;
+      border-radius: 10px;
+      background-color: var(--bg-color);
+      box-shadow: inset 3px 3px 6px var(--inset-shadow-dark),
+                  inset -3px -3px 6px var(--inset-shadow-light);
+      color: var(--text-color);
     }
 
     .emoji-choice {

--- a/frontend/static/css/theme.css
+++ b/frontend/static/css/theme.css
@@ -71,7 +71,9 @@ body {
 }
 
 #definitionBox,
-#chatBox {
+#chatBox,
+#shareBox,
+#shareLink {
   user-select: text;
   -webkit-user-select: text;
   -moz-user-select: text;

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -115,11 +115,15 @@ if (copyLobbyLink && LOBBY_CODE) {
         shareLink.value = url;
         shareModal.style.display = 'flex';
         openDialog(shareModal);
+        shareLink.focus();
+        shareLink.select();
       });
     } else {
       shareLink.value = url;
       shareModal.style.display = 'flex';
       openDialog(shareModal);
+      shareLink.focus();
+      shareLink.select();
     }
   });
 }


### PR DESCRIPTION
## Summary
- show the share link text when the share modal opens
- style the share link input to match other fields
- allow text selection in the share dialog

## Testing
- `python -m pytest -q`
- `npm run cypress` *(fails: cypress not found)*
- `terraform -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f20d506c832fbaefa43944928386