### PR TITLE
fix vite missing during build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,8 @@
 FROM node:20-alpine AS frontend-builder
 WORKDIR /app/frontend
 COPY frontend/package.json frontend/package-lock.json ./
-RUN npm ci --omit=dev
+# Install all dependencies so the Vite bundler is available
+RUN npm ci
 COPY frontend/ ./
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- update frontend builder to include dev dependencies so Vite installs

## Testing
- `pytest -q`
- `npx cypress run` *(fails: Your system is missing the dependency: Xvfb)*
- `terraform init -backend=false` *(fails: terraform: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864888cbc0c832f9027082fd4dc7dc9