### PR TITLE
Update tests docs and local terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ the options menu.
 
 ## Testing
 
-Run the unit tests from the repository root. Make sure Pytest and Node.js are
-installed (`pip install pytest` and `node --version` should succeed) and then
-run:
+Run the test suite from the repository root. Ensure Pytest and Node.js are
+installed (`pip install pytest` and `node --version` should succeed). Cypress
+requires an Xvfb display server when running headless and Terraform 1.4 or
+newer must also be available. Once these dependencies are installed, run:
 
 ```bash
 python -m pytest -v

--- a/infra/terraform/backend.tf
+++ b/infra/terraform/backend.tf
@@ -1,3 +1,3 @@
 terraform {
-  backend "s3" {}
+  backend "local" {}
 }


### PR DESCRIPTION
## Summary
- switch Terraform backend to local for testing
- clarify testing prerequisites in README

## Testing
- `python -m pytest -v`
- `xvfb-run -a npx cypress run --browser electron --headless`
- `terraform plan -input=false -lock=false -var-file=../live/variables.tfvars`

------
https://chatgpt.com/codex/tasks/task_e_68648aaaf5e8832f8f31f239394c24d9