### PR TITLE
Fix compose data volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ docker compose up --build
 Stop the containers with `docker compose down`.
 
 The compose file mounts your `backend/` directory so changes trigger a reload.
+It also mounts the `data/` folder read-only so the default word list and
+definitions cache are always available.
 If you run the optional frontend service it provides hot module reloading on
 port `3000`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - ./backend:/app/backend
       - ./frontend/dist:/app/backend/static
+      - ./data:/app/data:ro
   frontend:
     image: node:20-alpine
     working_dir: /app/frontend


### PR DESCRIPTION
## Summary
- mount the `data/` directory into the web container so assets load
- document data volume in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686496e34bc4832f9039eaeda1489558