### PR TITLE
feat(lobby): persist and fetch newly created lobbies

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -72,8 +72,9 @@ def load_server():
 
 
 @pytest.fixture
-def server_env():
+def server_env(tmp_path):
     server, request = load_server()
+    server.LOBBIES_FILE = tmp_path / 'lobbies.json'
     # basic game state
     server.WORDS = ['apple', 'enter', 'crane', 'crate', 'trace']
     server.current_state.target_word = 'apple'
@@ -1147,4 +1148,18 @@ def test_lobby_kick_missing_player(server_env):
     resp = server.lobby_kick(code)
     assert isinstance(resp, tuple)
     assert resp[1] == 404
+
+
+def test_create_lobby_then_get_state(server_env):
+    server, request = server_env
+
+    create_resp = server.lobby_create()
+    code = create_resp['id']
+
+    request.method = 'GET'
+    request.json = None
+    state = server.lobby_state(code)
+
+    assert state['phase'] == 'waiting'
+    assert code in server.LOBBIES
 


### PR DESCRIPTION
## Summary
- ensure lobbies are persisted to disk when Redis isn't configured
- load lobby data from persistence in `get_lobby`
- write lobby state immediately after creation
- store lobbies in a temporary file during tests
- add unit test verifying lobby GET works right after creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68649a33caac832f9dfa91fab9c881a0