### PR TITLE
Introduce runtime dir and mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ frontend/dist/
 .venv/
 game_persist.json
 analytics.log
+
+runtime/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,13 @@ services:
       - FLASK_ENV=development
       - FLASK_RUN_PORT=5001
       - FLASK_APP=backend.server
+      - GAME_FILE=/app/runtime/game_persist.json
+      - LOBBIES_FILE=/app/runtime/lobbies.json
     volumes:
       - ./backend:/app/backend
       - ./frontend/dist:/app/backend/static
       - ./data:/app/data:ro
+      - ./runtime:/app/runtime
   frontend:
     image: node:20-alpine
     working_dir: /app/frontend

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,9 @@ COPY data/sgb-words.txt /app/data/sgb-words.txt
 COPY data/offline_definitions.json /app/data/offline_definitions.json
 COPY --from=frontend-builder /app/frontend/dist/ ./backend/static/
 
+# Ensure runtime directory exists and correct ownership for appuser
+RUN chown -R appuser:appuser /app && mkdir -p /app/runtime
+
 EXPOSE 5001
 USER appuser
 


### PR DESCRIPTION
## Summary
- ignore new runtime directory
- configure Dockerfile to own `/app` and include `/app/runtime`
- mount runtime directory and set persistence env vars in compose

## Testing
- `pytest -q`
- `docker compose build` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68649ca15eb0832fbee72abb5a52a7ed