### PR TITLE
fix: set /assets static url

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -53,7 +53,7 @@ except Exception:  # pragma: no cover - optional dependency
 CLOSE_CALL_WINDOW = 2.0  # seconds
 
 STATIC_PATH = Path(__file__).resolve().parent / "static"
-app = Flask(__name__, static_folder=str(STATIC_PATH), static_url_path="")
+app = Flask(__name__, static_folder=str(STATIC_PATH), static_url_path="/assets")
 app.secret_key = "a_wordle_secret"
 CORS(app)
 


### PR DESCRIPTION
## Summary
- host Flask static assets from `/assets`

## Testing
- `python -m pytest -v`
- `npx cypress run` *(fails: needs cypress installation)*
- `terraform plan -lock=false` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68649ea3e0cc832fa83776f7e3db895b