### PR TITLE
fix: correct static asset directory

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -52,8 +52,10 @@ except Exception:  # pragma: no cover - optional dependency
 
 CLOSE_CALL_WINDOW = 2.0  # seconds
 
-STATIC_PATH = Path(__file__).resolve().parent / "static"
-app = Flask(__name__, static_folder=str(STATIC_PATH), static_url_path="/assets")
+STATIC_PATH = Path(__file__).resolve().parent / "static" / "assets"
+app = Flask(
+    __name__, static_folder=str(STATIC_PATH), static_url_path="/assets"
+)
 app.secret_key = "a_wordle_secret"
 CORS(app)
 


### PR DESCRIPTION
## Summary
- adjust Flask static folder path to include Vite's `assets` directory

## Testing
- `python -m pytest -q`
- `npm run cypress` *(fails: Xvfb missing)*
- `npm run build`
- `terraform plan -input=false -lock=false -var-file=../live/variables.tfvars` *(fails: configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864a37b92d0832fbc74839d339eedfe