### PR TITLE
fix: expose vite port and add SPA fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The compose file mounts your `backend/` directory so changes trigger a reload.
 It also mounts the `data/` folder read-only so the default word list and
 definitions cache are always available.
 If you run the optional frontend service it provides hot module reloading on
-port `3000`.
+port `5173`.
 
 Environment variables such as `FLASK_ENV` and `VITE_API_URL` can be set in the
 compose file or a `.env` file.
@@ -208,7 +208,7 @@ Docker Compose defines two profiles:
   docker compose --profile dev up --build
   ```
 
-  This exposes the Vite dev server on <http://localhost:3000>. It depends on the
+  This exposes the Vite dev server on <http://localhost:5173>. It depends on the
   API container so the backend is ready when the dev UI starts.
 
 AWS deployments always use the production profile.

--- a/backend/server.py
+++ b/backend/server.py
@@ -1091,6 +1091,15 @@ def css_files(filename):
 def lobby_css_files(filename):
     return css_files(filename)
 
+
+@app.route('/<path:requested_path>')
+def spa_fallback_route(requested_path: str):
+    """Send index.html for client-side routes."""
+    if requested_path.startswith(('api/', 'static/', 'assets/')) or requested_path in ('favicon.ico', 'robots.txt'):
+        return '', 404
+    root = STATIC_DIR if (STATIC_DIR / 'index.html').exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root), 'index.html')
+
 if __name__ == "__main__":
     load_data()
     if not current_state.target_word:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,13 @@ services:
   frontend:
     image: node:20-alpine
     working_dir: /app/frontend
-    command: sh -c "npm install && npm run dev -- --host"
+    command: sh -c "npm install && npm run dev -- --host --port 5173"
     environment:
       - VITE_API_URL=http://web:5001
     depends_on:
       - web
     ports:
-      - "3000:3000"
+      - "5173:5173"
     volumes:
       - ./frontend:/app/frontend
     profiles:


### PR DESCRIPTION
## Summary
- expose frontend dev server on port 5173
- document new dev port in README
- add Flask fallback route so SPA handles client-side paths

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a661c418832f9fb2be993d66e180