### PR TITLE
feat: use env var for Vite proxy

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vite'
 
+const apiUrl = process.env.VITE_API_URL
+
 export default defineConfig({
   base: '',
   server: {
     proxy: {
       '/lobby': {
-        target: 'http://localhost:5001',
+        target: apiUrl,
         changeOrigin: true
       }
     }


### PR DESCRIPTION
## Summary
- use the `VITE_API_URL` environment variable as the Vite dev server proxy target

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864abb2d910832f952c1d632b871664