### PR TITLE
Consolidate frontend build into Flask image

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -62,7 +62,6 @@ CORS(app)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s:%(message)s")
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-DEV_FRONTEND_DIR = BASE_DIR / "frontend"
 STATIC_DIR = BASE_DIR / "backend" / "static"
 DATA_DIR = BASE_DIR / "data"
 
@@ -1038,42 +1037,36 @@ def health() -> Any:
 @app.route("/")
 def index():
     """Serve the landing page."""
-    root = STATIC_DIR if (STATIC_DIR / "index.html").exists() else DEV_FRONTEND_DIR
-    return send_from_directory(str(root), "index.html")
+    return send_from_directory(str(STATIC_DIR), "index.html")
 
 
 @app.route("/landing.css")
 def landing_css():
     """Serve the landing page stylesheet."""
-    root = STATIC_DIR if (STATIC_DIR / "landing.css").exists() else DEV_FRONTEND_DIR
-    return send_from_directory(str(root), "landing.css")
+    return send_from_directory(str(STATIC_DIR), "landing.css")
 
 
 @app.route("/landing.js")
 def landing_js():
     """Serve the landing page script."""
-    root = STATIC_DIR if (STATIC_DIR / "landing.js").exists() else DEV_FRONTEND_DIR
-    return send_from_directory(str(root), "landing.js")
+    return send_from_directory(str(STATIC_DIR), "landing.js")
 
 @app.route("/game")
 def game_page():
     """Serve the main game client."""
-    root = STATIC_DIR if (STATIC_DIR / "game.html").exists() else DEV_FRONTEND_DIR
-    return send_from_directory(str(root), "game.html")
+    return send_from_directory(str(STATIC_DIR), "game.html")
 
 
 @app.route("/lobby/<code>")
 def lobby_page(code: str):
     """Serve the game client for a specific lobby."""
-    root = STATIC_DIR if (STATIC_DIR / "game.html").exists() else DEV_FRONTEND_DIR
-    return send_from_directory(str(root), "game.html")
+    return send_from_directory(str(STATIC_DIR), "game.html")
 
 # Serve static JavaScript modules
 @app.route('/static/js/<path:filename>')
 @app.route('/js/<path:filename>')
 def js_files(filename):
-    root = STATIC_DIR if (STATIC_DIR / 'static' / 'js').exists() else DEV_FRONTEND_DIR
-    return send_from_directory(str(root / 'static' / 'js'), filename)
+    return send_from_directory(str(STATIC_DIR / 'static' / 'js'), filename)
 
 # Support asset requests when game.html is served from /lobby/<code>
 @app.route('/lobby/static/js/<path:filename>')
@@ -1084,8 +1077,7 @@ def lobby_js_files(filename):
 @app.route('/static/css/<path:filename>')
 @app.route('/css/<path:filename>')
 def css_files(filename):
-    root = STATIC_DIR if (STATIC_DIR / 'static' / 'css').exists() else DEV_FRONTEND_DIR
-    return send_from_directory(str(root / 'static' / 'css'), filename)
+    return send_from_directory(str(STATIC_DIR / 'static' / 'css'), filename)
 
 @app.route('/lobby/static/css/<path:filename>')
 def lobby_css_files(filename):
@@ -1097,8 +1089,7 @@ def spa_fallback_route(requested_path: str):
     """Send index.html for client-side routes."""
     if requested_path.startswith(('api/', 'static/', 'assets/')) or requested_path in ('favicon.ico', 'robots.txt'):
         return '', 404
-    root = STATIC_DIR if (STATIC_DIR / 'index.html').exists() else DEV_FRONTEND_DIR
-    return send_from_directory(str(root), 'index.html')
+    return send_from_directory(str(STATIC_DIR), 'index.html')
 
 if __name__ == "__main__":
     load_data()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,20 +13,6 @@ services:
       - LOBBIES_FILE=/app/runtime/lobbies.json
     volumes:
       - ./backend:/app/backend
-      - ./frontend/dist:/app/backend/static
       - ./data:/app/data:ro
       - ./runtime:/app/runtime
-  frontend:
-    image: node:20-alpine
-    working_dir: /app/frontend
-    command: sh -c "npm install && npm run dev -- --host --port 5173"
-    environment:
-      - VITE_API_URL=http://web:5001
-    depends_on:
-      - web
-    ports:
-      - "5173:5173"
-    volumes:
-      - ./frontend:/app/frontend
-    profiles:
-      - dev
+

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,15 +1,5 @@
 import { defineConfig } from 'vite'
 
-const apiUrl = process.env.VITE_API_URL
-
 export default defineConfig({
-  base: '',
-  server: {
-    proxy: {
-      '/lobby': {
-        target: apiUrl,
-        changeOrigin: true
-      }
-    }
-  }
+  base: ''
 })


### PR DESCRIPTION
## Summary
- remove dev Vite container from compose
- have Flask serve built assets only
- drop dev frontend fallbacks from server
- stop Vite proxying to Flask

## Testing
- `pytest -q`
- `npm run cypress` *(fails: cypress not found)*
- `terraform init -backend=false infra/terraform` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653246d3c8832fa41ed4b3251a7eb7