### PR TITLE
Fix Quick Play asset routing

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -62,6 +62,7 @@ CORS(app)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s:%(message)s")
 
 BASE_DIR = Path(__file__).resolve().parent.parent
+DEV_FRONTEND_DIR = BASE_DIR / "frontend"
 STATIC_DIR = BASE_DIR / "backend" / "static"
 DATA_DIR = BASE_DIR / "data"
 
@@ -1037,36 +1038,42 @@ def health() -> Any:
 @app.route("/")
 def index():
     """Serve the landing page."""
-    return send_from_directory(str(STATIC_DIR), "index.html")
+    root = STATIC_DIR if (STATIC_DIR / "index.html").exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root), "index.html")
 
 
 @app.route("/landing.css")
 def landing_css():
     """Serve the landing page stylesheet."""
-    return send_from_directory(str(STATIC_DIR), "landing.css")
+    root = STATIC_DIR if (STATIC_DIR / "landing.css").exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root), "landing.css")
 
 
 @app.route("/landing.js")
 def landing_js():
     """Serve the landing page script."""
-    return send_from_directory(str(STATIC_DIR), "landing.js")
+    root = STATIC_DIR if (STATIC_DIR / "landing.js").exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root), "landing.js")
 
 @app.route("/game")
 def game_page():
     """Serve the main game client."""
-    return send_from_directory(str(STATIC_DIR), "game.html")
+    root = STATIC_DIR if (STATIC_DIR / "game.html").exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root), "game.html")
 
 
 @app.route("/lobby/<code>")
 def lobby_page(code: str):
     """Serve the game client for a specific lobby."""
-    return send_from_directory(str(STATIC_DIR), "game.html")
+    root = STATIC_DIR if (STATIC_DIR / "game.html").exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root), "game.html")
 
 # Serve static JavaScript modules
 @app.route('/static/js/<path:filename>')
 @app.route('/js/<path:filename>')
 def js_files(filename):
-    return send_from_directory(str(STATIC_DIR / 'static' / 'js'), filename)
+    root = STATIC_DIR if (STATIC_DIR / 'static' / 'js').exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root / 'static' / 'js'), filename)
 
 # Support asset requests when game.html is served from /lobby/<code>
 @app.route('/lobby/static/js/<path:filename>')
@@ -1077,7 +1084,8 @@ def lobby_js_files(filename):
 @app.route('/static/css/<path:filename>')
 @app.route('/css/<path:filename>')
 def css_files(filename):
-    return send_from_directory(str(STATIC_DIR / 'static' / 'css'), filename)
+    root = STATIC_DIR if (STATIC_DIR / 'static' / 'css').exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root / 'static' / 'css'), filename)
 
 @app.route('/lobby/static/css/<path:filename>')
 def lobby_css_files(filename):
@@ -1089,7 +1097,8 @@ def spa_fallback_route(requested_path: str):
     """Send index.html for client-side routes."""
     if requested_path.startswith(('api/', 'static/', 'assets/')) or requested_path in ('favicon.ico', 'robots.txt'):
         return '', 404
-    return send_from_directory(str(STATIC_DIR), 'index.html')
+    root = STATIC_DIR if (STATIC_DIR / 'index.html').exists() else DEV_FRONTEND_DIR
+    return send_from_directory(str(root), 'index.html')
 
 if __name__ == "__main__":
     load_data()


### PR DESCRIPTION
## Summary
- support running without frontend build by falling back to source directory

## Testing
- `pytest -q`
- `xvfb-run -a npx cypress run --browser electron --headless` *(fails: support file missing)*
- `terraform plan -input=false -lock=false -var-file=../live/variables.tfvars` *(fails: insufficient origin blocks)*

------
https://chatgpt.com/codex/tasks/task_e_686597b2cbd0832fab57a54b17480098