### PR TITLE
Enable multi-page Vite build

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,5 +1,13 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-  base: ''
+  base: '',
+  build: {
+    rollupOptions: {
+      input: {
+        index: 'index.html',
+        game: 'game.html'
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- set up multiple entry points in `vite.config.js` so `game.html` also builds

## Testing
- `pytest -q`
- `npm run cypress` *(fails: Xvfb missing)*
- `terraform plan -input=false -lock=false` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6865beda5528832fa2cac8a60f55f326