### PR TITLE
fix frontend asset paths

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-  base: '',
+  base: '/',
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- use absolute base path in Vite config so built HTML references `/assets/...`

## Testing
- `python -m pytest -q`
- `xvfb-run -a npx cypress run --browser electron --headless` *(fails: support file missing)*
- `npm run build`
- `terraform init -backend=false -reconfigure`
- `terraform plan -input=false -lock=false -var-file=../live/variables.tfvars` *(fails: insufficient blocks)*

------
https://chatgpt.com/codex/tasks/task_e_6865c3fb23e4832fb24f9c3f552bcce2