### PR TITLE
Fix Docker static asset path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN npm ci
 COPY frontend/ ./
 # Produce static assets under /frontend/dist. Only these files are copied
 # into the runtime stage so the final image stays slim.
+RUN mkdir -p /app/backend/static
 RUN npm run build
 
 # Stage 2: run Python backend


### PR DESCRIPTION
## Summary
- ensure Docker build creates a backend static directory before building frontend assets

## Testing
- `pytest -q`
- `npm run cypress` *(fails: missing Xvfb)*
- `terraform --version` *(fails: command not found)*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865cd5f0720832fa799eb170d09f92c