### PR TITLE
Add player_id tracking for multi-player IP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ of the overall flow.
 - **Word definition popup** when a game ends so everyone can learn the meaning of the
   solution.
 - **In-game chat box** so players can talk while solving the puzzle together.
+- **Unique player IDs** allow multiple devices on the same IP to join without
+  overwriting each other's emoji.
 - **Dark mode toggle** and responsive layout for small screens.
 - **Hold‑to‑reset button** (or instant reset once the game is over).
 - **Inactive player detection** – entries on the leaderboard fade if a player has not
@@ -72,6 +74,10 @@ Each lobby exposes a set of REST endpoints under `/lobby/<id>`:
 - `POST /lobby/<id>/reset` – start a new round (host token required)
 - `POST /lobby/<id>/kick` – remove a player from the lobby (host token required)
 - `GET /lobby/<id>/stream` – Server‑Sent Events channel
+
+`POST /emoji` responds with a `player_id` that uniquely identifies the browser.
+Include this id with all subsequent requests so multiple players on the same IP
+can join concurrently.
 
 The SSE stream pushes state updates in real time. The client falls back to
 polling these endpoints if the stream disconnects.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,6 +19,7 @@ This document provides a high level view of how the landing page and lobby syste
 1. **Landing page** – The player begins on `/` and can create or join a lobby. A POST to `/lobby` returns a six‑character code and host token. Joining uses `GET /lobby/<id>/state`.
 2. **Lobby view** – `/lobby/<id>` loads the game client which fetches the current state and subscribes to `GET /lobby/<id>/stream` for real‑time updates.
 3. **Backend** – `server.py` manages a dictionary of lobby objects in memory. Each lobby tracks players, chat, guesses and timestamps. Data is persisted either to a JSON file when running in single instance mode or to Redis when `REDIS_URL` is configured.
+   Players are identified by a short `player_id` returned when claiming an emoji. This id is stored in `localStorage` and sent with every request so multiple devices can join from the same IP without conflict.
 4. **SSE updates** – Each lobby maintains its own set of listeners so that state broadcasts only reach the correct lobby.
 
 This model supports any number of concurrent lobbies while keeping the API stateless. Clients reconnect using the stored lobby id and host token.

--- a/frontend/static/js/api.js
+++ b/frontend/static/js/api.js
@@ -25,12 +25,12 @@ export async function getState(emoji, lobbyId) {
  * @param {string} emoji - Player identifier.
  * @returns {Promise<Object>} Guess response payload.
  */
-export async function sendGuess(guess, emoji, lobbyId) {
+export async function sendGuess(guess, emoji, playerId, lobbyId) {
   const url = lobbyId ? `/lobby/${lobbyId}/guess` : '/guess';
   const r = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ guess, emoji })
+    body: JSON.stringify({ guess, emoji, player_id: playerId })
   });
   return r.json();
 }
@@ -55,12 +55,12 @@ export async function resetGame(lobbyId, hostToken) {
  * @param {string} emoji - Emoji avatar.
  * @returns {Promise<Object>} Response payload.
  */
-export async function sendEmoji(emoji, lobbyId) {
+export async function sendEmoji(emoji, playerId, lobbyId) {
   const url = lobbyId ? `/lobby/${lobbyId}/emoji` : '/emoji';
   const r = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ emoji })
+    body: JSON.stringify({ emoji, player_id: playerId })
   });
   return r.json();
 }
@@ -71,12 +71,12 @@ export async function sendEmoji(emoji, lobbyId) {
  * @param {string} emoji - Player identifier.
  * @returns {Promise<Response>} Raw fetch response.
  */
-export async function sendHeartbeat(emoji, lobbyId) {
+export async function sendHeartbeat(emoji, playerId, lobbyId) {
   const url = lobbyId ? `/lobby/${lobbyId}/state` : '/state';
   return fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ emoji })
+    body: JSON.stringify({ emoji, player_id: playerId })
   });
 }
 
@@ -87,12 +87,12 @@ export async function sendHeartbeat(emoji, lobbyId) {
  * @param {string} emoji - Player emoji.
  * @returns {Promise<Object>} Response payload.
  */
-export async function sendChatMessage(text, emoji, lobbyId) {
+export async function sendChatMessage(text, emoji, playerId, lobbyId) {
   const url = lobbyId ? `/lobby/${lobbyId}/chat` : '/chat';
   const r = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text, emoji })
+    body: JSON.stringify({ text, emoji, player_id: playerId })
   });
   return r.json();
 }
@@ -116,12 +116,12 @@ export async function getChatMessages(lobbyId) {
  * @param {string} emoji - Player identifier.
  * @returns {Promise<Object>} Hint response payload.
  */
-export async function requestHint(col, emoji, lobbyId) {
+export async function requestHint(col, emoji, playerId, lobbyId) {
   const url = lobbyId ? `/lobby/${lobbyId}/hint` : '/hint';
   const r = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ col, emoji })
+    body: JSON.stringify({ col, emoji, player_id: playerId })
   });
   return r.json();
 }

--- a/frontend/static/js/emoji.js
+++ b/frontend/static/js/emoji.js
@@ -10,6 +10,10 @@ export function getMyEmoji() {
   return localStorage.getItem('myEmoji') || null;
 }
 
+export function getMyPlayerId() {
+  return localStorage.getItem('playerId') || null;
+}
+
 /**
  * Persist the player's chosen emoji locally.
  *
@@ -17,6 +21,10 @@ export function getMyEmoji() {
  */
 export function setMyEmoji(e) {
   localStorage.setItem('myEmoji', e);
+}
+
+export function setMyPlayerId(pid) {
+  if (pid) localStorage.setItem('playerId', pid);
 }
 
 export const allEmojis = [
@@ -48,8 +56,9 @@ export function showEmojiModal(takenEmojis, {
     btn.style.pointerEvents = takenEmojis.includes(e) ? 'none' : 'auto';
 
     btn.onclick = async () => {
-    const data = await sendEmoji(e, window.LOBBY_CODE);
+    const data = await sendEmoji(e, getMyPlayerId(), window.LOBBY_CODE);
     if (data.status === 'ok') {
+      if (data.player_id) setMyPlayerId(data.player_id);
       if (skipAutoCloseRef) skipAutoCloseRef.value = false;
       setMyEmoji(e);
       if (typeof onChosen === 'function') onChosen(e);


### PR DESCRIPTION
## Summary
- track player_id in server state and persist
- generate new player_id from `/emoji` when absent and return in response
- require player_id for `/guess`, `/hint`, `/chat` and heartbeat
- store player_id client-side and include with API calls
- adjust tests for player_id and add concurrency test
- document new identification mechanism

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d0f34c2c832f956fb29958b5fc0c