### PR TITLE
Add pointer-events style to waiting overlay

### DIFF
--- a/frontend/game.html
+++ b/frontend/game.html
@@ -105,7 +105,7 @@
       </div>
     </div>
 
-    <div id="waitingOverlay" role="alert" aria-live="polite">Waiting for players…</div>
+    <div id="waitingOverlay" role="alert" aria-live="polite">Waiting for players… start by guessing!</div>
 
     <div id="titleBar">
       <div id="resetWrapper">

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -1246,6 +1246,7 @@
       justify-content: center;
       color: var(--text-color);
       font-size: 1.2rem;
+      pointer-events: none;
     }
 
     #closeCallBox {

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -264,6 +264,11 @@ def test_waiting_overlay_present():
     text = GAME.read_text(encoding='utf-8')
     assert '<div id="waitingOverlay"' in text
 
+def test_waiting_overlay_pointer_events_none():
+    css = read_css()
+    rules = [m.group(0) for m in re.finditer(r'#waitingOverlay\s*{[^}]*}', css)]
+    assert any('pointer-events: none' in r for r in rules)
+
 
 def test_show_message_desktop_behavior():
     script = """


### PR DESCRIPTION
## Summary
- update waiting overlay style to not intercept pointer events
- tweak waiting overlay prompt text to encourage guessing
- test CSS rule for the overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865daea3098832fb962b2d1f00182b9