### PR TITLE
Allow overlay dismissal and smaller mobile layout

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -213,6 +213,26 @@
       }
     }
 
+    @media (max-width: 400px) {
+      #board {
+        grid-template-columns: repeat(5, 42px);
+        grid-gap: 4px;
+        max-width: 226px;
+      }
+
+      .tile {
+        width: 42px;
+        height: 42px;
+        font-size: 20px;
+      }
+
+      .key {
+        min-width: 28px;
+        height: 40px;
+        font-size: 14px;
+      }
+    }
+
     /* ─────────────────────────────────────────────
        C) Medium mode adjustments
        ───────────────────────────────────────────── */

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -79,6 +79,15 @@ const copyLobbyLink = document.getElementById('copyLobbyLink');
 const leaveLobby = document.getElementById('leaveLobby');
 const lobbyHeader = document.getElementById('lobbyHeader');
 const waitingOverlay = document.getElementById('waitingOverlay');
+let waitingOverlayDismissed = false;
+if (waitingOverlay) {
+  document.addEventListener('click', () => {
+    if (waitingOverlay.style.display !== 'none') {
+      waitingOverlayDismissed = true;
+      waitingOverlay.style.display = 'none';
+    }
+  });
+}
 // Ensure the close-call popup starts hidden even if CSS hasn't loaded yet
 closeCallPopup.style.display = 'none';
 const chatNotify = document.getElementById('chatNotify');
@@ -496,7 +505,11 @@ function applyState(state) {
     playerCountEl.textContent = `${activeEmojis.length} player${activeEmojis.length !== 1 ? 's' : ''}`;
   }
   if (waitingOverlay) {
-    waitingOverlay.style.display = state.phase === 'waiting' ? 'flex' : 'none';
+    if (state.phase !== 'waiting') {
+      waitingOverlayDismissed = false;
+    }
+    waitingOverlay.style.display =
+      state.phase === 'waiting' && !waitingOverlayDismissed ? 'flex' : 'none';
   }
   renderLeaderboard();
   renderPlayerSidebar();

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -269,6 +269,16 @@ def test_waiting_overlay_pointer_events_none():
     rules = [m.group(0) for m in re.finditer(r'#waitingOverlay\s*{[^}]*}', css)]
     assert any('pointer-events: none' in r for r in rules)
 
+def test_waiting_overlay_dismiss_logic_present():
+    text = (SRC_DIR / 'main.js').read_text(encoding='utf-8')
+    assert 'waitingOverlayDismissed' in text
+    assert 'document.addEventListener' in text
+
+def test_extra_small_mobile_rules_present():
+    css = read_css()
+    assert '@media (max-width: 400px)' in css
+    assert 'grid-template-columns: repeat(5, 42px)' in css
+
 
 def test_show_message_desktop_behavior():
     script = """


### PR DESCRIPTION
## Summary
- enable dismissing the "Waiting for players" overlay on user tap
- hide overlay when the phase changes and re-show only if not dismissed
- add extra-small mobile breakpoint for screens under 400px
- extend frontend tests for overlay dismissal logic and new CSS rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d0343418832f8962c07d0c586e09