### PR TITLE
feat: add logging to backend

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -169,7 +169,7 @@ No outstanding tasks.
 - [ ] Resource Proper Disposal
   - Close files and surfaces correctly.
   - Call `pygame.quit()` in every exit pathway.
-- [ ] Add Logging
+- [x] Add Logging
   - Integrate Python logging.
   - Replace print statements with logger calls.
   - Monitor asset loading, state changes, and errors.


### PR DESCRIPTION
## Summary
- add structured logging via module logger
- log significant events such as emoji selection, guesses, lobby creation and reset
- mark Add Logging item complete in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866efcc23e8832faced6fa84f2a0a93