### PR TITLE
fix: remove pause overlay

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -175,7 +175,6 @@ No outstanding tasks.
   - Monitor asset loading, state changes, and errors.
 - [ ] User Feedback Enhancements
   - [x] Add prompts for key input.
-  - Add pause screen overlays.
   - Add transition animations or effects.
 - [ ] Automated Regression Testing
   - Create unit tests for core logic (collision, scoring, state transitions).


### PR DESCRIPTION
## Summary
- revert pause overlay implementation
- remove pause overlay requirement from TODO

## Testing
- `pytest -q`
- `npm --prefix frontend run cypress` *(fails: cypress not found)*
- `terraform -chdir=infra plan` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_686704f52fd4832fb4e5ffe123f551d8