### PR TITLE
feat/ui: animate leaderboard updates

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -1193,6 +1193,16 @@
       margin: 0 5px;
       font-size: 1.25em;
       min-width: 50px;
+      transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+
+    .leaderboard-entry.flash {
+      animation: lb-flash 0.4s ease;
+    }
+
+    @keyframes lb-flash {
+      from { transform: scale(0.8); opacity: 0.3; }
+      to { transform: scale(1); opacity: 1; }
     }
 
     .hint-badge {

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -347,6 +347,7 @@ function renderLeaderboard() {
   leaderboard.forEach(entry => {
     const node = document.createElement('span');
     node.className = 'leaderboard-entry' + (myEmoji === entry.emoji ? ' me' : '');
+    node.classList.add('flash');
     if (entry.last_active !== undefined && (now - entry.last_active > 300)) {
       node.classList.add('inactive');
     }
@@ -375,6 +376,9 @@ function renderLeaderboard() {
     }
 
     lb.appendChild(node);
+    node.addEventListener('animationend', () => {
+      node.classList.remove('flash');
+    }, { once: true });
   });
 
   centerLeaderboardOnMe();


### PR DESCRIPTION
## Summary
- animate leaderboard entry updates with a short flash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686707e35c3c832fa4ab8b7c4c1c20b2