### PR TITLE
Start tackling WWF To-Do list

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -175,7 +175,7 @@ No outstanding tasks.
   - Monitor asset loading, state changes, and errors.
 - [ ] User Feedback Enhancements
   - [x] Add prompts for key input.
-  - Add transition animations or effects.
+  - [x] Add transition animations or effects.
 - [ ] Automated Regression Testing
   - Create unit tests for core logic (collision, scoring, state transitions).
   - Use mocks or simulations of the event loop for automated testing.

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -1092,6 +1092,12 @@
       100% { opacity: 0; transform: translateY(-10px); }
     }
 
+    /* ─── Overlay Fade-Out Animation ─── */
+    @keyframes fadeOutOverlay {
+      from { opacity: 1; }
+      to { opacity: 0; }
+    }
+
     @keyframes tileResetOut {
       to {
         box-shadow: 0 0 0 var(--shadow-color-dark),
@@ -1277,6 +1283,10 @@
       color: var(--text-color);
       font-size: 1.2rem;
       pointer-events: none;
+    }
+
+    #waitingOverlay.fade-out {
+      animation: fadeOutOverlay 0.3s forwards;
     }
 
     #closeCallBox {

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -110,7 +110,15 @@ if (waitingOverlay) {
   document.addEventListener('click', () => {
     if (waitingOverlay.style.display !== 'none') {
       waitingOverlayDismissed = true;
-      waitingOverlay.style.display = 'none';
+      waitingOverlay.classList.add('fade-out');
+      waitingOverlay.addEventListener(
+        'animationend',
+        () => {
+          waitingOverlay.style.display = 'none';
+          waitingOverlay.classList.remove('fade-out');
+        },
+        { once: true }
+      );
     }
   });
 }
@@ -543,8 +551,12 @@ function applyState(state) {
     if (state.phase !== 'waiting') {
       waitingOverlayDismissed = false;
     }
-    waitingOverlay.style.display =
-      state.phase === 'waiting' && !waitingOverlayDismissed ? 'flex' : 'none';
+    if (state.phase === 'waiting' && !waitingOverlayDismissed) {
+      waitingOverlay.classList.remove('fade-out');
+      waitingOverlay.style.display = 'flex';
+    } else if (!waitingOverlay.classList.contains('fade-out')) {
+      waitingOverlay.style.display = 'none';
+    }
   }
   renderLeaderboard();
   renderPlayerSidebar();

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -296,6 +296,14 @@ def test_waiting_overlay_dismiss_logic_present():
     assert 'waitingOverlayDismissed' in text
     assert 'document.addEventListener' in text
 
+
+def test_waiting_overlay_fade_out_animation():
+    css = read_css()
+    assert '@keyframes fadeOutOverlay' in css
+    assert '#waitingOverlay.fade-out' in css
+    text = (SRC_DIR / 'main.js').read_text(encoding='utf-8')
+    assert "waitingOverlay.classList.add('fade-out')" in text
+
 def test_extra_small_mobile_rules_present():
     css = read_css()
     assert '@media (max-width: 400px)' in css


### PR DESCRIPTION
## Summary
- add fade-out overlay animation for waiting screen
- update JS logic for dismissing the overlay
- test fade-out styling & JS hook
- mark the transition animation task done in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68671ef2c9d0832fab77a6a8fddca190