### PR TITLE
Close SSE connections on exit

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -169,6 +169,7 @@ No outstanding tasks.
 - [ ] Resource Proper Disposal
   - Close files and surfaces correctly.
   - Call `pygame.quit()` in every exit pathway.
+  - [x] Close SSE connections on page unload and lobby exit.
 - [x] Add Logging
   - Integrate Python logging.
   - Replace print statements with logger calls.

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -187,6 +187,10 @@ if (shareClose) {
 
 if (leaveLobby && LOBBY_CODE) {
   leaveLobby.addEventListener('click', () => {
+    if (eventSource) {
+      try { eventSource.close(); } catch {}
+      eventSource = null;
+    }
     stopAllSounds();
     window.location.href = '/';
   });
@@ -982,4 +986,10 @@ chatForm.addEventListener('submit', async (e) => {
   fetchState();
 });
 
-window.addEventListener('beforeunload', stopAllSounds);
+window.addEventListener('beforeunload', () => {
+  if (eventSource) {
+    try { eventSource.close(); } catch {}
+    eventSource = null;
+  }
+  stopAllSounds();
+});

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -714,3 +714,14 @@ function showMessage(msg){ shown = msg; }
     data = json.loads(result.stdout.strip())
     assert data['state'] == 'orig'
     assert data['msg'] == 'fail'
+
+
+def test_beforeunload_closes_event_source():
+    text = (SRC_DIR / 'main.js').read_text(encoding='utf-8')
+    assert re.search(r"beforeunload[^{]*\{[^\}]*eventSource\.close", text, re.DOTALL)
+
+
+def test_leave_lobby_closes_event_source():
+    text = (SRC_DIR / 'main.js').read_text(encoding='utf-8')
+    m = re.search(r"leaveLobby\.addEventListener\('click',\s*\(\)\s*=>\s*\{([^}]*)\}", text)
+    assert m and 'eventSource.close' in m.group(1)


### PR DESCRIPTION
## Summary
- close EventSource when leaving lobby or unloading the page
- ensure sounds stop and SSE cleanup runs on exit
- update To-Do list for resource disposal
- test for new beforeunload and leave lobby cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867218fb3a4832f990368a100be19fa