### PR TITLE
fix: improve mobile layout

### DIFF
--- a/frontend/game.html
+++ b/frontend/game.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <title>Wordle Game (Hard Mode, Shared)</title>
   <link rel="stylesheet" href="static/css/theme.css">
   <link rel="stylesheet" href="static/css/layout.css">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <title>Wordle With Friends</title>
   <link rel="stylesheet" href="static/css/theme.css">
   <link rel="stylesheet" href="landing.css">

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -370,15 +370,18 @@
       --border-color: #4a4a4f;
     }
 
+    html, body {
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+    }
+
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       text-align: center;
-      margin: 0;
-      padding: 0;
       background-color: var(--bg-color);
       color: var(--text-color);
       height: calc(var(--vh, 1vh) * 100);
-      overflow: hidden;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -392,7 +395,9 @@
       padding: 20px;
       width: 100%;
       height: 100%;
-      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
     }
 
 
@@ -776,9 +781,10 @@
       display: flex;
       justify-content: center;
       align-items: flex-end;
-      margin: 20px auto;
+      margin: 10px auto 0;
       width: max-content;
       position: relative;
+      flex: 1 1 auto;
     }
 
     #stampContainer {
@@ -1015,6 +1021,7 @@
     #keyboard {
       display: inline-block;
       margin-top: 5px;
+      flex: 0 0 30%;
     }
 
     .keyboard-row {

--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -151,6 +151,10 @@ export function positionSidePanels(boardArea, historyBox, definitionBox, chatBox
 export function updateVH() {
   const vh = window.innerHeight * 0.01;
   document.documentElement.style.setProperty('--vh', `${vh}px`);
+  const container = document.getElementById('appContainer');
+  if (container) {
+    container.style.height = `${window.innerHeight}px`;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- update viewport meta tags in HTML templates
- restructure app container to use flexbox
- allocate space between board and keyboard
- sync layout height with viewport on resize

## Testing
- `pytest -q`
- `npx cypress run` *(fails: missing Xvfb)*
- `terraform init` *(fails: command not found)*
- `terraform plan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af0a61a44832fb3d3f2b23e9ff49e