### PR TITLE
feat: handle mobile keyboard

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -923,6 +923,9 @@ window.addEventListener('resize', () => {
 });
 updateVH();
 window.addEventListener('resize', updateVH);
+if (window.visualViewport) {
+  window.visualViewport.addEventListener('resize', updateVH);
+}
 
 async function selectHint(col) {
   hideHintTooltip();

--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -149,11 +149,12 @@ export function positionSidePanels(boardArea, historyBox, definitionBox, chatBox
  * Update the CSS `--vh` custom property to handle mobile browser chrome.
  */
 export function updateVH() {
-  const vh = window.innerHeight * 0.01;
+  const height = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+  const vh = height * 0.01;
   document.documentElement.style.setProperty('--vh', `${vh}px`);
   const container = document.getElementById('appContainer');
   if (container) {
-    container.style.height = `${window.innerHeight}px`;
+    container.style.height = `${height}px`;
   }
 }
 


### PR DESCRIPTION
## Summary
- adapt updateVH helper to use `visualViewport` height
- listen for `visualViewport` resize events

## Testing
- `pytest -q`
- `npm run cypress --silent` *(fails: cypress not found)*
- `terraform init -input=false` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af7af115c832f988df1eacd7c5915