### PR TITLE
feat: improve responsive layout

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -785,6 +785,7 @@
       width: max-content;
       position: relative;
       flex: 1 1 auto;
+      min-height: 0; /* let the board shrink if needed */
     }
 
     #stampContainer {
@@ -1021,7 +1022,8 @@
     #keyboard {
       display: inline-block;
       margin-top: 5px;
-      flex: 0 0 30%;
+      flex: 0 1 30%; /* allow shrinking when space is tight */
+      min-height: 150px; /* maintain usability on small screens */
     }
 
     .keyboard-row {

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -926,6 +926,12 @@ window.addEventListener('resize', updateVH);
 if (window.visualViewport) {
   window.visualViewport.addEventListener('resize', updateVH);
 }
+window.addEventListener('orientationchange', () => {
+  updateVH();
+  positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
+  applyLayoutMode();
+  if (latestState) renderEmojiStamps(latestState.guesses);
+});
 
 async function selectHint(col) {
   hideHintTooltip();


### PR DESCRIPTION
## Summary
- make the board area able to shrink when space is limited
- allow the keyboard to shrink and add a minimum height
- update layout on orientation change

## Testing
- `python -m pytest -q`
- `npm --prefix frontend ci`
- `npm --prefix frontend run cypress` *(fails: Xvfb missing)*
- `terraform init -backend=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afe9b0034832fb8e133077adb0925