### PR TITLE
feat: improve responsive layout

### DIFF
--- a/frontend/landing.css
+++ b/frontend/landing.css
@@ -22,7 +22,7 @@ header {
 #heroCard {
   margin: 2rem auto;
   padding: 1rem;
-  max-width: 400px;
+  width: min(90vw, 25rem);
   text-align: center;
   border-radius: 12px;
   box-shadow: 4px 4px 8px var(--shadow-color-dark),

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -182,9 +182,9 @@
         margin-left: 0;
       }
       #holdReset {
-        width: 70px;
-        height: 32px;
-        font-size: 14px;
+        width: clamp(4rem, 20vw, 4.5rem);
+        height: 2rem;
+        font-size: 0.875rem;
         border-radius: 8px;
         box-shadow: 3px 3px 6px var(--shadow-color-dark),
                     -3px -3px 6px var(--shadow-color-light);
@@ -229,7 +229,7 @@
       #historyBox,
       #definitionBox,
       #chatBox {
-        width: 220px;
+        width: clamp(14rem, 30vw, 17rem);
       }
 
       #optionsToggle {
@@ -571,7 +571,7 @@
       position: absolute;
       top: 100px;
       left: 20px;
-      width: 260px;
+      width: clamp(14rem, 25vw, 16rem);
       max-height: 70vh;
       overflow-y: auto;
       scrollbar-width: none;
@@ -592,7 +592,7 @@
       position: absolute;
       top: 100px;
       right: 20px;
-      width: 260px;
+      width: clamp(14rem, 25vw, 16rem);
       max-height: 70vh;
       overflow-y: auto;
       scrollbar-width: none;
@@ -613,7 +613,7 @@
       position: absolute;
       top: 100px;
       left: calc(100% + 20px);
-      width: 260px;
+      width: clamp(14rem, 25vw, 16rem);
       max-height: 70vh;
       display: flex;
       flex-direction: column;
@@ -905,8 +905,8 @@
     }
 
     #guessInput {
-      width: 180px;
-      margin-right: 10px;
+      width: clamp(10rem, 40vw, 11.25rem);
+      margin-right: 0.625rem;
       text-transform: uppercase;
     }
 
@@ -1118,8 +1118,8 @@
     }
 
     #holdReset {
-      width: 100px;
-      height: 45px;
+      width: clamp(5rem, 18vw, 6.25rem);
+      height: clamp(2.25rem, 6vh, 2.8rem);
       border: none;
       border-radius: 12px;
       font-size: 18px;
@@ -1311,7 +1311,7 @@
                   0 0 0 3px var(--shadow-color-light);
       border-radius: 12px;
       padding: 20px;
-      max-width: 420px;
+      max-width: min(90vw, 26.25rem);
       max-height: 90vh;
       overflow-y: auto;
       text-align: left;
@@ -1337,7 +1337,7 @@
       border-radius: 12px;
       padding: 20px;
       text-align: center;
-      max-width: 360px;
+      max-width: min(90vw, 22.5rem);
     }
 
     #shareActions {


### PR DESCRIPTION
## Summary
- tweak landing hero card width for responsive layout
- use viewport-relative sizing for history, definition, and chat boxes
- scale input and reset button dimensions with rem and viewport units
- make modal containers responsive

## Testing
- `npm run cypress` *(fails: missing Xvfb)*
- `pytest -q`
- `terraform init -input=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b19388fcc832f80be29ba58ae8755