### PR TITLE
Responsive board sizing

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -761,7 +761,7 @@
       justify-content: center;
       align-items: flex-end;
       margin: 10px auto 0;
-      width: max-content;
+      width: 100%;
       position: relative;
       flex: 1 1 auto;
       min-height: 0; /* let the board shrink if needed */

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -5,7 +5,7 @@ import { getState, sendEmoji, sendGuess, resetGame, sendHeartbeat, sendChatMessa
 import { renderChat } from './chat.js';
 import { setupTypingListeners, updateBoardFromTyping } from './keyboard.js';
 import { showMessage, announce, applyDarkModePreference, shakeInput, repositionResetButton,
-         positionSidePanels, updateVH, applyLayoutMode, isMobile, showPopup,
+         positionSidePanels, updateVH, applyLayoutMode, fitBoardToContainer, isMobile, showPopup,
          openDialog, closeDialog, focusFirstElement, setGameInputDisabled } from './utils.js';
 import { updateHintBadge } from './hintBadge.js';
 import { saveHintState, loadHintState } from './hintState.js';
@@ -900,6 +900,7 @@ applyDarkModePreference(menuDarkMode);
 menuSound.textContent = soundEnabled ? '🔊 Sound On' : '🔈 Sound Off';
 applyLayoutMode();
 createBoard(board, maxRows);
+fitBoardToContainer(maxRows);
 repositionResetButton();
 positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
 renderEmojiStamps([]);
@@ -924,6 +925,7 @@ window.addEventListener('resize', repositionResetButton);
 window.addEventListener('resize', () => {
   positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
   applyLayoutMode();
+  fitBoardToContainer(maxRows);
   if (latestState) renderEmojiStamps(latestState.guesses);
 });
 updateVH();
@@ -935,6 +937,7 @@ window.addEventListener('orientationchange', () => {
   updateVH();
   positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
   applyLayoutMode();
+  fitBoardToContainer(maxRows);
   if (latestState) renderEmojiStamps(latestState.guesses);
 });
 

--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -191,6 +191,40 @@ export function applyLayoutMode() {
 }
 
 /**
+ * Calculate a tile size that fits the board within the viewport.
+ * Prevents overlap with the header and leaderboard in full mode.
+ *
+ * @param {number} rows - Number of board rows
+ */
+export function fitBoardToContainer(rows = 6) {
+  const boardArea = document.getElementById('boardArea');
+  if (!boardArea) return;
+  const titleBar = document.getElementById('titleBar');
+  const leaderboard = document.getElementById('leaderboard');
+  const inputArea = document.getElementById('inputArea');
+  const keyboard = document.getElementById('keyboard');
+
+  const style = getComputedStyle(document.documentElement);
+  const gap = parseFloat(style.getPropertyValue('--tile-gap')) || 10;
+  const maxSize = 60; // keep in sync with layout.css
+  const width = boardArea.clientWidth;
+
+  const availHeight =
+    document.documentElement.clientHeight -
+    (titleBar ? titleBar.offsetHeight : 0) -
+    (leaderboard ? leaderboard.offsetHeight : 0) -
+    (inputArea ? inputArea.offsetHeight : 0) -
+    (keyboard ? keyboard.offsetHeight : 0) -
+    20; // account for margins
+
+  const sizeByWidth = (width - gap * 4) / 5;
+  const sizeByHeight = (availHeight - gap * (rows - 1)) / rows;
+  const size = Math.min(maxSize, sizeByWidth, sizeByHeight);
+
+  document.documentElement.style.setProperty('--tile-size', `${size}px`);
+}
+
+/**
  * Place a popup near an anchor element while clamping to the viewport.
  *
  * @param {HTMLElement} popup


### PR DESCRIPTION
## Summary
- prevent board container overflow
- size tiles relative to viewport and header space

## Testing
- `pytest -q`
- `npm run cypress` *(fails: cypress not found)*
- `terraform --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9f86575c832f814ff71310229821