### PR TITLE
fix: blurred modals and click-off dismissal

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -1226,6 +1226,7 @@
 
     #emojiModal {
       background: rgba(0, 0, 0, 0.33);
+      backdrop-filter: blur(4px);
       position: fixed;
       z-index: 102;
       top: 0;
@@ -1248,6 +1249,7 @@
 
     #closeCallPopup {
       background: rgba(0, 0, 0, 0.33);
+      backdrop-filter: blur(4px);
       position: fixed;
       z-index: 101;
       top: 0;
@@ -1295,6 +1297,7 @@
 
     #infoPopup {
       background: rgba(0, 0, 0, 0.33);
+      backdrop-filter: blur(4px);
       position: fixed;
       z-index: 101;
       top: 0;
@@ -1321,6 +1324,7 @@
 
     #shareModal {
       background: rgba(0, 0, 0, 0.33);
+      backdrop-filter: blur(4px);
       position: fixed;
       z-index: 101;
       top: 0;

--- a/frontend/static/js/emoji.js
+++ b/frontend/static/js/emoji.js
@@ -1,5 +1,8 @@
 import { sendEmoji } from './api.js';
-import { openDialog, closeDialog } from './utils.js';
+import { openDialog, closeDialog, enableClickOffDismiss } from './utils.js';
+
+const emojiModal = typeof document !== 'undefined' ? document.getElementById('emojiModal') : null;
+enableClickOffDismiss(emojiModal);
 
 /**
  * Retrieve the player's stored emoji identifier.

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -6,7 +6,7 @@ import { renderChat } from './chat.js';
 import { setupTypingListeners, updateBoardFromTyping } from './keyboard.js';
 import { showMessage, announce, applyDarkModePreference, shakeInput, repositionResetButton,
          positionSidePanels, updateVH, applyLayoutMode, fitBoardToContainer, isMobile, showPopup,
-         openDialog, closeDialog, focusFirstElement, setGameInputDisabled } from './utils.js';
+         openDialog, closeDialog, focusFirstElement, setGameInputDisabled, enableClickOffDismiss } from './utils.js';
 import { updateHintBadge } from './hintBadge.js';
 import { saveHintState, loadHintState } from './hintState.js';
 
@@ -137,6 +137,10 @@ const playerSidebar = document.getElementById('playerSidebar');
 const playerList = document.getElementById('playerList');
 const playerToggleBtn = document.getElementById('playerToggle');
 const playerCloseBtn = document.getElementById('playerClose');
+
+enableClickOffDismiss(closeCallPopup);
+enableClickOffDismiss(infoPopup);
+enableClickOffDismiss(shareModal);
 
 let chatWiggleTimer = null;
 

--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -324,6 +324,21 @@ export function closeDialog(dialog) {
 }
 
 /**
+ * Enable click-off dismissal for a dialog by closing it when the
+ * background overlay is clicked.
+ *
+ * @param {HTMLElement} dialog
+ */
+export function enableClickOffDismiss(dialog) {
+  if (!dialog) return;
+  dialog.addEventListener('click', (e) => {
+    if (e.target === dialog) {
+      closeDialog(dialog);
+    }
+  });
+}
+
+/**
  * Focus the first focusable element within a container.
  *
  * @param {HTMLElement} container


### PR DESCRIPTION
## Summary
- blur popup backdrops and allow click-off dismissal
- expose reusable `enableClickOffDismiss` utility
- use the new utility for emoji, info, share and close-call popups

## Testing
- `pytest -q`
- `npm --prefix frontend run cypress` *(fails: `cypress` not found)*
- `terraform plan -lock=false -input=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec68ffeac832f8fcaf1c1cb1626ed