### PR TITLE
Make game name configurable

### DIFF
--- a/frontend/game.html
+++ b/frontend/game.html
@@ -116,7 +116,7 @@
           <span id="holdResetProgress"></span>
         </button>
       </div>
-      <h1>WordleWithFriends</h1>
+      <h1 id="gameTitle"></h1>
       <span id="titleHintBadge" class="hint-badge" style="display:none">🔍 x1</span>
     </div>
 

--- a/frontend/static/js/config.js
+++ b/frontend/static/js/config.js
@@ -1,0 +1,1 @@
+export const GAME_NAME = 'WordSquad';

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -9,6 +9,7 @@ import { showMessage, announce, applyDarkModePreference, shakeInput, repositionR
          openDialog, closeDialog, focusFirstElement, setGameInputDisabled, enableClickOffDismiss } from './utils.js';
 import { updateHintBadge } from './hintBadge.js';
 import { saveHintState, loadHintState } from './hintState.js';
+import { GAME_NAME } from './config.js';
 
 import { StateManager, STATES } from './stateManager.js';
 
@@ -77,6 +78,8 @@ const chatMessagesEl = document.getElementById('chatMessages');
 const chatForm = document.getElementById('chatForm');
 const chatInput = document.getElementById('chatInput');
 const historyClose = document.getElementById('historyClose');
+const gameTitle = document.getElementById('gameTitle');
+if (gameTitle) gameTitle.textContent = GAME_NAME;
 const definitionClose = document.getElementById('definitionClose');
 const chatClose = document.getElementById('chatClose');
 const optionsToggle = document.getElementById('optionsToggle');


### PR DESCRIPTION
## Summary
- make the game title configurable via `GAME_NAME`
- replace `WordleWithFriends` header with variable

## Testing
- `pytest -q`
- `npm run cypress` *(fails: missing Xvfb)*
- `terraform init` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef33c79f4832fa8886777ae29e91c