### PR TITLE
Rename game to WordSquad

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,6 +1,6 @@
 Purpose
 
-This file documents recommended practices, agent instructions, and prompt guidelines for contributors using AI assistants (such as GitHub Copilot, ChatGPT, or Codex) to enhance and maintain the Wordle With Friends codebase.
+This file documents recommended practices, agent instructions, and prompt guidelines for contributors using AI assistants (such as GitHub Copilot, ChatGPT, or Codex) to enhance and maintain the WordSquad codebase.
 
 Project Context
 • Repo: deveydtj/WWF

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Wordle With Friends (WWF)
+# WordSquad
 
-A small multiplayer adaptation of Wordle. The frontend lives under the
+WordSquad is a small multiplayer adaptation of Wordle. The frontend lives under the
 `frontend/` directory while `backend/server.py` provides a Flask API. The
 server supports **multiple lobbies**, each identified by a six character code.
 Every lobby maintains its own guesses, chat log and scoreboard while sharing

--- a/docs/DEPLOY_GUIDE.md
+++ b/docs/DEPLOY_GUIDE.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-This guide outlines the steps to deploy the Wordle With Friends infrastructure and API using Terraform and GitHub Actions.
+This guide outlines the steps to deploy the WordSquad infrastructure and API using Terraform and GitHub Actions.
 
 ## Prerequisites
 

--- a/docs/LANDING_PAGE_REQUIREMENTS.md
+++ b/docs/LANDING_PAGE_REQUIREMENTS.md
@@ -4,7 +4,7 @@ This document outlines the specifications for the planned landing page at `/`. I
 
 ## 1. Purpose
 
-The landing page introduces new and returning players to Wordle With Friends. It directs visitors into a lobby quickly while highlighting the game's features. The page must remember dark‑mode preference, chosen emoji, and the last lobby code using `localStorage`.
+The landing page introduces new and returning players to WordSquad. It directs visitors into a lobby quickly while highlighting the game's features. The page must remember dark‑mode preference, chosen emoji, and the last lobby code using `localStorage`.
 
 ## 2. Information Architecture
 

--- a/docs/LOCAL_SERVER_SETUP.md
+++ b/docs/LOCAL_SERVER_SETUP.md
@@ -1,6 +1,6 @@
 # Local Server Setup
 
-This guide explains how to start the development server for Wordle With Friends on your machine.
+This guide explains how to start the development server for WordSquad on your machine.
 
 1. **Verify prerequisites**
    - Python 3.11 or newer

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,7 +1,7 @@
-# Wordle With Friends Requirements
+# WordSquad Requirements
 
 This document summarizes the functional, UI/UX, and technical requirements for the
-browser-based "Wordle with Friends" project. It is derived from the project
+browser-based WordSquad project. It is derived from the project
 overview and should be kept up to date as features evolve.
 
 ## 1. Game Play

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,6 +1,6 @@
 # Development TODOs
 
-This file tracks outstanding tasks for "Wordle with Friends". Completed items are checked off. Remaining work is grouped by focus area.
+This file tracks outstanding tasks for WordSquad. Completed items are checked off. Remaining work is grouped by focus area.
 
 ## Completed
 
@@ -124,7 +124,7 @@ No outstanding tasks.
 ## Upcoming Milestones
 
 ### Project Hygiene
-- [ ] Rename all references to "Wordle With Friends" to the new game name throughout docs and code comments.
+- [ ] Rename all references to "Wordle With Friends" to the new game name "WordSquad" throughout docs and code comments.
 
 ### Backend Refactor to Multi-Lobby
   - `POST /lobby`
@@ -152,7 +152,7 @@ No outstanding tasks.
 
 ### Docs & Deliverables
 
-### To-Do List Workflow for WWF
+### To-Do List Workflow for WordSquad
 
   - Write a `setup.sh` or documentation to check Python version and dependencies.
   - Log missing asset errors during startup.

--- a/frontend/cypress/e2e/smoke.cy.js
+++ b/frontend/cypress/e2e/smoke.cy.js
@@ -1,6 +1,6 @@
 describe('Smoke', () => {
   it('loads the landing page', () => {
     cy.visit('/');
-    cy.contains('Wordle');
+    cy.contains('WordSquad');
   });
 });

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-  <title>Wordle Game (Hard Mode, Shared)</title>
+  <title>WordSquad Game (Hard Mode, Shared)</title>
   <link rel="stylesheet" href="static/css/theme.css">
   <link rel="stylesheet" href="static/css/layout.css">
 </head>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-  <title>Wordle With Friends</title>
+  <title>WordSquad</title>
   <link rel="stylesheet" href="static/css/theme.css">
   <link rel="stylesheet" href="landing.css">
 </head>
 <body>
 <div id="landingView">
   <header id="mainHeader">
-    <h1 id="logo">WWF</h1>
+    <h1 id="logo">WordSquad</h1>
     <span id="emojiDisplay" aria-label="Selected emoji"></span>
     <button id="darkToggle" aria-label="Toggle dark mode"></button>
     <nav>

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,7 +1,7 @@
 # Infrastructure Setup
 
 This Terraform configuration provisions the AWS resources required to host
-Wordle With Friends in production. It creates:
+WordSquad in production. It creates:
 
 - An S3 bucket for the static frontend assets
 - A CloudFront distribution backed by the bucket with HTTPS

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# Simple environment validation for WWF development
+# Simple environment validation for WordSquad development
 
 check_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- rename game to **WordSquad** in docs and frontend
- update Cypress smoke test
- tweak setup script comment

## Testing
- `pytest -q`
- `npx --yes cypress run --headless` *(fails: Xvfb missing)*
- `terraform init` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3297bbe0832f8697f614fa5fcdf9