### PR TITLE
Add docker start helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ docker compose up --build
 
 Stop the containers with `docker compose down`.
 
+Alternatively run `start_docker.sh` to reset your local repository and
+launch Docker Compose in one step:
+
+```bash
+./start_docker.sh
+```
+
 The compose file mounts your `backend/` directory so changes trigger a reload.
 It also mounts the `frontend/` folder to `/app/frontend` so the server can
 fall back to unbuilt assets during development. The `data/` folder is mounted

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# Start the WordSquad server in Docker after resetting the repository to the latest commit.
+# This script is intended for local development on macOS or Linux.
+
+# Determine repository root (directory containing this script)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Ensure Docker is available
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: Docker is not installed or not in PATH" >&2
+  exit 1
+fi
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+echo "Cleaning local changes on branch $BRANCH..."
+# Remove uncommitted changes and untracked files
+git fetch origin
+git reset --hard "origin/$BRANCH"
+git clean -fd
+
+echo "Bringing up Docker Compose..."
+# Stop any existing containers and rebuild the stack
+docker compose down --remove-orphans
+docker compose up --build


### PR DESCRIPTION
## Summary
- add `start_docker.sh` helper to reset repo and launch Docker Compose
- document the helper script in README

## Testing
- `pytest -q`
- `npm ci` *(fails: missing Xvfb)*
- `npm run cypress` *(fails: missing Xvfb)*
- `terraform plan` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68705b6370a4832f82759c9d224ed0e0