### PR TITLE
Fix: run cypress under xvfb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run Cypress smoke test
         working-directory: frontend
-        run: npm run cypress
+        run: xvfb-run -a npm run cypress
         continue-on-error: true
 
       - name: Build frontend


### PR DESCRIPTION
## Summary
- run Cypress tests in CI using xvfb

## Testing
- `python -m pytest -q`
- `cd frontend && xvfb-run -a npm run cypress`
- `cd frontend && npm run build`
- `cd infra/terraform && terraform fmt -check`
- `terraform init -reconfigure`
- `terraform plan -input=false -lock=false -var-file=../live/variables.tfvars`

------
https://chatgpt.com/codex/tasks/task_e_68705fb6bdd8832f8f451c66c8c82f34