### PR TITLE
Add Terraform CI wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ game_persist.json
 analytics.log
 
 runtime/
+.terraform/

--- a/infra/terraform/ci-plan.sh
+++ b/infra/terraform/ci-plan.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run Terraform init and plan for CI
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+terraform init -input=false
+terraform plan -input=false -var-file=../live/variables.tfvars "$@"


### PR DESCRIPTION
## Summary
- ignore `.terraform/` working directory
- add `ci-plan.sh` script for Terraform init/plan

## Testing
- `pytest -q`
- `npm run cypress`
- `bash infra/terraform/ci-plan.sh` *(fails: Insufficient origin/restrictions blocks)*

------
https://chatgpt.com/codex/tasks/task_e_687064a277e0832f82ae2da7c277878f