### PR TITLE
Add Terraform CI plan script

### DIFF
--- a/.codex.yaml
+++ b/.codex.yaml
@@ -20,7 +20,7 @@ test:
   - python -m pytest -q
   - cd frontend && xvfb-run -a npx cypress run --browser electron --headless && cd ..
   - cd frontend && npm run build
-  - cd infra/terraform && terraform fmt -check && terraform init -backend=false && terraform plan -input=false -lock=false -var-file=../live/variables.tfvars && cd ../..
+  - cd infra/terraform && terraform fmt -check && bash ci-plan.sh && cd ../..
 env:
   CYPRESS_CACHE_FOLDER: .cache/Cypress
   TF_IN_AUTOMATION: "1"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ game_persist.json
 analytics.log
 
 runtime/
+
+# Terraform state
+.terraform/

--- a/infra/terraform/ci-plan.sh
+++ b/infra/terraform/ci-plan.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Always run from the script directory
+cd "$(dirname "$0")"
+
+terraform init -reconfigure
+terraform plan -input=false -lock=false -var-file=../live/variables.tfvars


### PR DESCRIPTION
## Summary
- add `.terraform/` to `.gitignore`
- add reusable `infra/terraform/ci-plan.sh` script
- call new script from `.codex.yaml`

## Testing
- `python -m pytest -q`
- `cd frontend && xvfb-run -a npx cypress run --browser electron --headless`
- `npm run build`
- `cd infra/terraform && terraform fmt -check && bash ci-plan.sh`

------
https://chatgpt.com/codex/tasks/task_e_687064a277e0832f82ae2da7c277878f