### PR TITLE
Fix board alignment under title

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -767,12 +767,11 @@
     #boardArea {
       display: flex;
       justify-content: center;
-      align-items: flex-end;
+      align-items: flex-start;
       margin: 10px auto 0;
       width: 100%;
       position: relative;
-      flex: 1 1 auto;
-      min-height: 0; /* let the board shrink if needed */
+      flex: 0 0 auto;
     }
 
     #stampContainer {


### PR DESCRIPTION
## Summary
- keep board area anchored under the title by aligning to the top

## Testing
- `python -m pytest -v`
- `npm run cypress` *(fails: support file missing)*
- `bash infra/terraform/ci-plan.sh` *(fails: unsupported block type)*

------
https://chatgpt.com/codex/tasks/task_e_68707f0bb2f4832f9620ec5b84071645