### PR TITLE
fix: adjust layout on viewport changes

### DIFF
--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -156,6 +156,13 @@ export function updateVH() {
   if (container) {
     container.style.height = `${height}px`;
   }
+  const board = document.getElementById('board');
+  if (board) {
+    const rows = Math.max(1, Math.floor(board.children.length / 5));
+    fitBoardToContainer(rows);
+  } else {
+    fitBoardToContainer();
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- adjust `updateVH()` to recalc board size on viewport changes

## Testing
- `pytest -q`
- `npm run cypress --silent`
- `bash infra/terraform/ci-plan.sh` *(fails: Insufficient restrictions blocks)*

------
https://chatgpt.com/codex/tasks/task_e_6870846a4d38832f9404ee57c0a70fb6