### PR TITLE
Improve scaling for smaller screens

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -138,7 +138,8 @@
       }
 
       :root {
-        --tile-size: min(14vmin, 50px);
+        /* allow smaller tiles on narrow screens */
+        --tile-size: min(12vmin, 50px);
         --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
       }
 
@@ -219,7 +220,8 @@
 
     @media (max-width: 400px) {
       :root {
-        --tile-size: min(16vmin, 42px);
+        /* extra small devices */
+        --tile-size: min(12vmin, 36px);
         --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
       }
     }
@@ -283,7 +285,8 @@
       }
 
       :root {
-        --tile-size: min(11vmin, 55px);
+        /* medium screens scale slightly smaller */
+        --tile-size: min(10vmin, 50px);
         --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
       }
     }
@@ -325,7 +328,8 @@
       --absent-shadow-dark: #666a6c;
       --absent-shadow-light: #8a8e90;
       --border-color: transparent;
-      --tile-size: min(12vmin, 60px);
+      /* default maximum tile size */
+      --tile-size: min(11vmin, 60px);
       --tile-gap: calc(var(--tile-size) / 6);
       --ui-scale: 1;
       --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
@@ -1009,7 +1013,8 @@
       display: inline-block;
       margin-top: 5px;
       flex: 0 1 auto;
-      min-height: calc(var(--tile-size) * 2.7);
+      /* shrink keyboard height slightly for cramped screens */
+      min-height: calc(var(--tile-size) * 2.4);
     }
 
     .keyboard-row {

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -307,7 +307,7 @@ def test_waiting_overlay_fade_out_animation():
 def test_extra_small_mobile_rules_present():
     css = read_css()
     assert '@media (max-width: 400px)' in css
-    assert '--tile-size: min(16vmin, 42px)' in css
+    assert '--tile-size: min(12vmin, 36px)' in css
 
 
 def test_show_message_desktop_behavior():


### PR DESCRIPTION
## Summary
- adjust tile sizing rules for smaller viewports
- allow the keyboard to shrink more
- update frontend test expectations

## Testing
- `python -m pytest -q`
- `infra/terraform/ci-plan.sh` *(fails: insufficient restrictions/origin blocks)*

------
https://chatgpt.com/codex/tasks/task_e_68710961ccfc832f802fbf49ccc43f71