### PR TITLE
Improve small-screen layout

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -226,6 +226,14 @@
       }
     }
 
+    @media (max-width: 350px) {
+      :root {
+        /* very small devices */
+        --tile-size: min(8vmin, 28px);
+        --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
+      }
+    }
+
     /* ─────────────────────────────────────────────
        C) Medium mode adjustments
        ───────────────────────────────────────────── */

--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -210,7 +210,16 @@ export function fitBoardToContainer(rows = 6) {
   const root = document.documentElement;
   const style = getComputedStyle(root);
   const gap = parseFloat(style.getPropertyValue('--tile-gap')) || 10;
-  const maxSize = 60; // keep in sync with layout.css
+  // Use CSS --tile-size as an upper bound so media queries can limit scaling.
+  // Fallback to 60 if the computed value appears invalid (e.g. same as gap).
+  let cssLimit = parseFloat(style.getPropertyValue('--tile-size'));
+  if (isNaN(cssLimit)) {
+    cssLimit = 60;
+  } else {
+    const gapVal = parseFloat(style.getPropertyValue('--tile-gap')) || 0;
+    if (cssLimit <= gapVal + 1) cssLimit = 60;
+  }
+  const maxSize = Math.min(60, cssLimit); // keep 60 as absolute max
   const width = boardArea.clientWidth;
 
   const getHeights = () => {


### PR DESCRIPTION
## Summary
- allow smaller tiles and keyboard by adding an extra mobile breakpoint
- respect CSS limits in `fitBoardToContainer`

## Testing
- `pytest -q`
- `npm run cypress` *(fails: support file missing)*
- `bash infra/terraform/ci-plan.sh` *(fails: configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68716ebd698c832fbffa6db62e006f86