### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/frontend/landing.css
+++ b/frontend/landing.css
@@ -75,3 +75,26 @@ a:focus {
   height: 100vh;
   border: none;
 }
+
+/* Responsive header tweaks */
+header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+}
+@media (max-width: 480px) {
+  header {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  header h1 {
+    font-size: 1.5rem;
+  }
+  header img,
+  .scores img {
+    width: 24px;
+    height: 24px;
+  }
+}
+

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -1463,3 +1463,40 @@ body.players-open #playerSidebar {
 .player-row.inactive {
   opacity: 0.5;
 }
+/* --- Additional responsive tweaks --- */
+@media (max-width: 600px) {
+  #appContainer {
+    min-height: 100vh;
+  }
+  #board {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    gap: 0.5rem;
+  }
+  .tile {
+    width: calc((100vw - 2rem) / 6);
+    height: calc((100vw - 2rem) / 6);
+    margin: 0.25rem;
+  }
+  #titleBar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+@media (max-width: 480px) {
+  #titleBar {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  #titleBar h1 {
+    font-size: 1.5rem;
+    margin: 0;
+  }
+  #leaderboard {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+


### PR DESCRIPTION
## Summary
- tweak tiles to scale with viewport width
- switch board to CSS Grid and add header wrap for small screens
- expand landing page header styles for mobile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687290fb890c832fbda1e90b9b770e1a