### PR TITLE
Improve mobile layout styles

### DIFF
--- a/frontend/landing.css
+++ b/frontend/landing.css
@@ -7,16 +7,37 @@ body {
   color: var(--text-color);
 }
 
+#landingView {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 header {
   position: sticky;
   top: 0;
   display: flex;
-  justify-content: space-between;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: space-between;
   padding: 0.5rem 1rem;
   background: var(--bg-color);
   box-shadow: inset 0 -2px 4px var(--shadow-color-dark),
               inset 0 2px 4px var(--shadow-color-light);
+}
+
+@media (max-width: 480px) {
+  header {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  header h1 {
+    font-size: 1.5rem;
+  }
+  .scores img {
+    width: 24px;
+    height: 24px;
+  }
 }
 
 #heroCard {

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -144,14 +144,15 @@
       }
 
       #board {
-        grid-template-columns: repeat(5, var(--tile-size));
-        grid-gap: var(--tile-gap);
+        grid-template-columns: repeat(auto-fill, minmax(var(--tile-size), 1fr));
+        gap: var(--tile-gap);
         margin: 0;
       }
 
       .tile {
         width: var(--tile-size);
         height: var(--tile-size);
+        margin: 0.25rem;
         font-size: calc(var(--tile-size) * 0.44);
         border-radius: 4px;
         box-shadow: 3px 3px 6px var(--shadow-color-dark),
@@ -345,7 +346,7 @@
       --absent-shadow-light: #8a8e90;
       --border-color: transparent;
       /* default maximum tile size */
-      --tile-size: min(11vmin, 60px);
+      --tile-size: min(calc((100vw - 2rem) / 6), 60px);
       --tile-gap: calc(var(--tile-size) / 6);
       --ui-scale: 1;
       --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
@@ -398,6 +399,7 @@
       box-sizing: border-box;
       padding: 20px;
       width: 100%;
+      min-height: 100vh;
       height: 100%;
       display: flex;
       flex-direction: column;
@@ -779,8 +781,8 @@
     #board {
       margin: 0;
       display: grid;
-      grid-template-columns: repeat(5, var(--tile-size));
-      grid-gap: var(--tile-gap);
+      grid-template-columns: repeat(auto-fill, minmax(var(--tile-size), 1fr));
+      gap: var(--tile-gap);
       max-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
     }
 
@@ -833,6 +835,7 @@
     .tile {
       width: var(--tile-size);
       height: var(--tile-size);
+      margin: 0.25rem;
       border: 1px solid var(--border-color);
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Summary
- tweak tile-size to scale with viewport width
- convert board to auto-fill grid and add tile margins
- ensure container fills viewport height
- make landing header responsive

## Testing
- `pytest -q`
- `npm run cypress` *(fails: support file missing)*
- `terraform -chdir=infra/terraform plan -input=false` *(fails: required variables not set)*

------
https://chatgpt.com/codex/tasks/task_e_687290fb890c832fbda1e90b9b770e1a