### PR TITLE
feat: improve board sizing logic

### DIFF
--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -756,7 +756,7 @@ console.log(JSON.stringify({ out, css: docEl.style }));
         capture_output=True, text=True, check=True
     )
     data = json.loads(result.stdout.strip())
-    assert round(data['out']['tile'], 2) == 29.17
-    assert round(data['out']['board'], 2) == 185.83
-    assert data['css']['--tile-size'].startswith('29.16')
-    assert data['css']['--board-width'].startswith('185.83')
+    assert round(data['out']['tile'], 2) == 25
+    assert round(data['out']['board'], 2) == 165
+    assert data['css']['--tile-size'].startswith('25')
+    assert data['css']['--board-width'].startswith('165')


### PR DESCRIPTION
## Summary
- refine `fitBoardToContainer` to better account for keyboard space and mobile layouts
- improve `updateVH` and add `adjustKeyboardForViewport` helper
- update frontend test to reflect new sizing logic

## Testing
- `pytest -q`
- `npm run cypress` *(fails: support file missing)*
- `bash infra/terraform/ci-plan.sh` *(fails: insufficient blocks)*

------
https://chatgpt.com/codex/tasks/task_e_68729cf837d8832fb7e040d8db987644