### PR TITLE
Improve mobile viewport handling

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -6,7 +6,8 @@ import { renderChat } from './chat.js';
 import { setupTypingListeners, updateBoardFromTyping } from './keyboard.js';
 import { showMessage, announce, applyDarkModePreference, shakeInput, repositionResetButton,
          positionSidePanels, updateVH, applyLayoutMode, fitBoardToContainer, isMobile, showPopup,
-         openDialog, closeDialog, focusFirstElement, setGameInputDisabled, enableClickOffDismiss } from './utils.js';
+         openDialog, closeDialog, focusFirstElement, setGameInputDisabled, enableClickOffDismiss,
+         adjustKeyboardForViewport } from './utils.js';
 import { updateHintBadge } from './hintBadge.js';
 import { saveHintState, loadHintState } from './hintState.js';
 import { GAME_NAME } from './config.js';
@@ -928,24 +929,40 @@ initEventStream();
 setInterval(checkInactivity, 5000);
 document.addEventListener('keydown', onActivity);
 document.addEventListener('click', onActivity);
-window.addEventListener('resize', repositionResetButton);
 window.addEventListener('resize', () => {
+  repositionResetButton();
   positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
   applyLayoutMode();
   fitBoardToContainer(maxRows);
+  adjustKeyboardForViewport();
   if (latestState) renderEmojiStamps(latestState.guesses);
 });
 updateVH();
 window.addEventListener('resize', updateVH);
 if (window.visualViewport) {
-  window.visualViewport.addEventListener('resize', updateVH);
+  window.visualViewport.addEventListener('resize', () => {
+    updateVH();
+    adjustKeyboardForViewport();
+  });
 }
 window.addEventListener('orientationchange', () => {
   updateVH();
   positionSidePanels(boardArea, historyBox, definitionBoxEl, chatBox);
   applyLayoutMode();
   fitBoardToContainer(maxRows);
+  adjustKeyboardForViewport();
   if (latestState) renderEmojiStamps(latestState.guesses);
+});
+
+// Add a timeout for orientation change to handle delayed layout updates
+let orientationTimeout;
+window.addEventListener('orientationchange', () => {
+  clearTimeout(orientationTimeout);
+  orientationTimeout = setTimeout(() => {
+    updateVH();
+    fitBoardToContainer(maxRows);
+    adjustKeyboardForViewport();
+  }, 300);
 });
 
 async function selectHint(col) {

--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -411,3 +411,17 @@ export function showPopup(popup, anchor) {
   positionPopup(popup, anchor);
   openDialog(popup);
 }
+
+/**
+ * Adjust the on-screen keyboard position when the visual viewport changes.
+ */
+export function adjustKeyboardForViewport() {
+  const keyboard = document.getElementById('keyboard');
+  if (!keyboard) return;
+  if (window.visualViewport) {
+    const offset = Math.max(0, window.innerHeight - window.visualViewport.height);
+    keyboard.style.transform = `translateY(-${offset}px)`;
+  } else {
+    keyboard.style.transform = '';
+  }
+}


### PR DESCRIPTION
## Summary
- import `adjustKeyboardForViewport`
- adjust keyboard location on viewport resize/orientation
- implement helper in `utils.js`

## Testing
- `python -m pytest -q`
- `npm run cypress` *(fails: supportFile missing)*

------
https://chatgpt.com/codex/tasks/task_e_68729d08c7cc832f865d39aec791d10f