### PR TITLE
Fix mobile board layout

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -1469,12 +1469,12 @@ body.players-open #playerSidebar {
   }
   #board {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    grid-template-columns: repeat(5, 1fr);
     gap: 0.5rem;
   }
   .tile {
-    width: calc((100vw - 2rem) / 6);
-    height: calc((100vw - 2rem) / 6);
+    width: calc((100vw - 2rem) / 5);
+    height: calc((100vw - 2rem) / 5);
     margin: 0.25rem;
   }
   #titleBar {


### PR DESCRIPTION
## Summary
- force board grid to always use five columns on small screens

## Testing
- `pytest -q`
- `npm run cypress --silent` *(fails: supportFile missing)*
- `./infra/terraform/ci-plan.sh` *(fails: insufficient origin blocks)*

------
https://chatgpt.com/codex/tasks/task_e_6872b2ac0510832fa3dac7af9581ac25