### PR TITLE
Fix mobile title bar layout

### DIFF
--- a/frontend/static/css/responsive.css
+++ b/frontend/static/css/responsive.css
@@ -240,7 +240,7 @@
 
   /* Additional mobile layout fixes */
   #titleBar {
-    flex-direction: column;
+    flex-direction: row;
     gap: 0.5rem;
   }
   


### PR DESCRIPTION
## Summary
- keep title bar horizontal on mobile so reset button sits next to the game title

## Testing
- `npm ci`
- `npm run build`
- `python -m pytest -v` *(fails: FileNotFoundError in several frontend tests)*

------
https://chatgpt.com/codex/tasks/task_e_687300128fac832fa1d80e7f44eb6f0c