### PR TITLE
Refactor panel layout to use CSS grid

### DIFF
--- a/frontend/game.html
+++ b/frontend/game.html
@@ -127,28 +127,6 @@
       </div>
     </div>
 
-    <!-- Game History Panel -->
-    <div id="historyBox" role="dialog" aria-modal="true" aria-labelledby="historyHeading">
-      <button id="historyClose" class="close-btn">✖</button>
-      <h3 id="historyHeading">History</h3>
-      <ul id="historyList"></ul>
-    </div>
-
-    <!-- Leaderboard moved to lobbyHeader -->
-    <div id="definitionBox" role="dialog" aria-modal="true" aria-labelledby="definitionHeading">
-      <button id="definitionClose" class="close-btn">✖</button>
-      <h3 id="definitionHeading" class="visually-hidden">Definition</h3>
-      <div id="definitionText"></div>
-    </div>
-    <div id="chatBox" role="dialog" aria-modal="true" aria-labelledby="chatHeading">
-      <button id="chatClose" class="close-btn" type="button">✖</button>
-      <h3 id="chatHeading" class="visually-hidden">Chat</h3>
-      <div id="chatMessages"></div>
-      <form id="chatForm">
-        <input id="chatInput" type="text" maxlength="140" autocomplete="off" />
-        <button id="chatSend" type="submit">Send</button>
-      </form>
-    </div>
     <div id="playerSidebar" role="dialog" aria-label="Players">
       <button id="playerClose" class="close-btn" type="button">✖</button>
       <ul id="playerList"></ul>
@@ -168,7 +146,11 @@
     <div id="gameLayoutContainer">
       <!-- Left Panel -->
       <div id="leftPanel" class="layout-panel">
-        <!-- History box will be positioned here for non-mobile -->
+        <div id="historyBox" role="dialog" aria-modal="true" aria-labelledby="historyHeading">
+          <button id="historyClose" class="close-btn">✖</button>
+          <h3 id="historyHeading">History</h3>
+          <ul id="historyList"></ul>
+        </div>
       </div>
 
       <!-- Center Panel -->
@@ -257,7 +239,20 @@
 
       <!-- Right Panel -->
       <div id="rightPanel" class="layout-panel">
-        <!-- Chat and definition boxes will be positioned here for non-mobile -->
+        <div id="definitionBox" role="dialog" aria-modal="true" aria-labelledby="definitionHeading">
+          <button id="definitionClose" class="close-btn">✖</button>
+          <h3 id="definitionHeading" class="visually-hidden">Definition</h3>
+          <div id="definitionText"></div>
+        </div>
+        <div id="chatBox" role="dialog" aria-modal="true" aria-labelledby="chatHeading">
+          <button id="chatClose" class="close-btn" type="button">✖</button>
+          <h3 id="chatHeading" class="visually-hidden">Chat</h3>
+          <div id="chatMessages"></div>
+          <form id="chatForm">
+            <input id="chatInput" type="text" maxlength="140" autocomplete="off" />
+            <button id="chatSend" type="submit">Send</button>
+          </form>
+        </div>
       </div>
     </div> <!-- end gameLayoutContainer -->
   </div>

--- a/frontend/static/css/components/board.css
+++ b/frontend/static/css/components/board.css
@@ -4,7 +4,9 @@
 
 /* Board area container - centered layout */
 #boardArea {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 40px) auto;
+  column-gap: 10px;
   justify-content: center;
   align-items: flex-start;
   margin: 5px auto 0;
@@ -25,6 +27,7 @@
 
 /* Game board grid */
 #board {
+  grid-column: 2;
   margin: 0;
   display: grid;
   grid-template-columns: repeat(5, var(--tile-size));
@@ -34,28 +37,21 @@
 
 /* Board stamps and confetti */
 #stampContainer {
-  position: absolute;
-  top: 0;
-  /* Position stamps exactly 10px to the left of the board edge */
-  /* Calculate from center: 50% - (half board width + 40px stamp width + 10px gap) */
-  /* Default positioning when no panels are open */
-  left: max(calc(50% - (var(--board-width) / 2) - 40px - 10px), 10px);
+  grid-column: 1;
+  grid-row: 1;
+  position: relative;
   pointer-events: none;
   z-index: var(--z-panel-interactive); /* Ensure stamps appear above history panel */
   display: none;
-  /* Dynamic width to accommodate any emoji characters */
-  width: fit-content; /* Let container grow with emoji content */
-  min-width: 40px; /* Minimum width to fit in available space */
-  max-width: 40px; /* Constrain width to fit in limited space */
+  width: 40px;
+  min-width: 40px;
+  max-width: 40px;
   height: calc(6 * (var(--tile-size) + var(--tile-gap)) - var(--tile-gap)); /* Match board height */
-  transition: left 0.3s ease; /* Smooth transition when panels open/close */
+  justify-self: end;
+  align-self: start;
 }
 
 /* Stamp positioning when history panel is open - avoid overlap */
-body.history-open #stampContainer {
-  left: max(calc(50% - (var(--board-width) / 2) - 40px - 10px), 280px);
-}
-
 /* Show stamps on everything except mobile */
 @media (min-width: 601px) {
   #stampContainer {
@@ -65,38 +61,6 @@ body.history-open #stampContainer {
 
 /* Medium mode stamp positioning - account for history panel at left edge when open */
 @media (min-width: 601px) and (max-width: 900px) {
-  body.history-open #stampContainer {
-    /* History panel width in medium mode: clamp(14rem, 30vw, 17rem) ≈ 224-272px */
-    /* Add 20px buffer to ensure clear separation */
-    left: max(calc(50% - (var(--board-width) / 2) - 40px - 10px), 300px);
-  }
-}
-
-/* Standard desktop stamp positioning - account for default history panel when open */
-@media (min-width: 901px) and (max-width: 1199px) {
-  body.history-open #stampContainer {
-    /* History panel width: clamp(14rem, 25vw, 16rem) ≈ 224-256px */
-    /* Position stamps with sufficient clearance */
-    left: max(calc(50% - (var(--board-width) / 2) - 40px - 10px), 280px);
-  }
-}
-
-/* Large desktop stamp positioning when history is open */
-@media (min-width: 1200px) and (max-width: 1799px) {
-  body.history-open #stampContainer {
-    /* Larger screens have more space, but still need to avoid history panel */
-    left: max(calc(50% - (var(--board-width) / 2) - 40px - 10px), 280px);
-  }
-}
-
-/* Ultra-wide screen stamp positioning adjustment for better clearance when history is open */
-@media (min-width: 1800px) {
-  body.history-open #stampContainer {
-    /* Increase minimum left position to ensure stamps stay clear of expanded panels */
-    left: max(calc(50% - (var(--board-width) / 2) - 40px - 10px), 320px);
-  }
-}
-
 /* Emoji stamps next to board */
 .emoji-stamp {
   position: absolute;

--- a/frontend/static/css/components/panels.css
+++ b/frontend/static/css/components/panels.css
@@ -193,17 +193,14 @@ body.dark-mode .close-btn:active {
 
 /* History Panel */
 #historyBox {
-  position: absolute;
-  top: 100px;
-  left: 20px;
-  width: clamp(14rem, 25vw, 16rem);
-  max-height: 70vh;
+  width: 100%;
+  max-width: 100%;
   overflow-y: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
   background: var(--bg-color);
-  padding: 10px;
-  border-radius: 8px;
+  padding: 20px;
+  border-radius: 20px;
   box-shadow:
     inset 2px 2px 5px var(--shadow-color-dark),
     inset -2px -2px 5px var(--shadow-color-light);
@@ -258,17 +255,14 @@ body.dark-mode .close-btn:active {
 
 /* Definition Panel */
 #definitionBox {
-  position: absolute;
-  top: 100px;
-  right: 20px;
-  width: clamp(14rem, 25vw, 16rem);
-  max-height: 70vh;
+  width: 100%;
+  max-width: 100%;
   overflow-y: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
   background: var(--bg-color);
-  padding: 10px;
-  border-radius: 8px;
+  padding: 20px;
+  border-radius: 20px;
   box-shadow:
     inset 2px 2px 5px var(--shadow-color-dark),
     inset -2px -2px 5px var(--shadow-color-light);
@@ -281,17 +275,14 @@ body.dark-mode .close-btn:active {
 
 /* Chat Panel */
 #chatBox {
-  position: absolute;
-  top: 100px;
-  left: calc(100% + 20px);
-  width: clamp(14rem, 25vw, 16rem);
-  max-height: 70vh;
+  width: 100%;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
   background: var(--bg-color);
   padding: 36px 10px 10px;
-  border-radius: 8px;
+  border-radius: 20px;
   box-shadow:
     inset 2px 2px 5px var(--shadow-color-dark),
     inset -2px -2px 5px var(--shadow-color-light);
@@ -449,84 +440,12 @@ body.players-open #playerSidebar {
   #definitionClose {
     display: none;
   }
-  
+
   #optionsToggle {
     display: block;
   }
-  
+
   #chatNotify {
     display: block;
-  }
-  
-  #boardArea {
-    position: relative;
-  }
-  
-  /* Large screen panel positioning - align with board level and add gaps */
-  body #historyBox {
-    position: absolute !important;
-    top: 140px !important; /* Move down to align with board level */
-    left: calc(50% - var(--board-width) / 2 - 365px) !important; /* Move further left to give room for stamps */
-    right: auto !important;
-    width: 280px !important;
-    max-height: calc(100vh - 240px) !important;
-    transform-origin: left center !important;
-  }
-  
-  body #definitionBox {
-    position: absolute !important;
-    top: 180px !important; /* Move down further to avoid options gear overlap */
-    right: calc(50% - var(--board-width) / 2 - 370px) !important; /* Move further right to avoid options button */
-    left: auto !important;
-    width: 280px !important;
-    max-height: 300px !important; /* Limit height to prevent overlap with chat panel */
-    transform-origin: right center !important;
-  }
-  
-  body:not([data-mode='medium']) #chatBox {
-    position: absolute !important;
-    /* Dynamic top position will be set by JavaScript based on definition panel height */
-    right: calc(50% - var(--board-width) / 2 - 370px) !important; /* Match definition panel position */
-    left: auto !important;
-    width: 280px !important;
-    max-height: calc(100vh - 510px) !important; /* Adjust max-height for the new position */
-    transform-origin: right center !important;
-  }
-  
-  body:not(.history-open) #historyBox {
-    transform: scale(0);
-    opacity: 0;
-    pointer-events: none;
-  }
-  
-  body:not(.definition-open) #definitionBox {
-    transform: scale(0);
-    opacity: 0;
-    pointer-events: none;
-  }
-  
-  body:not(.chat-open) #chatBox {
-    transform: scale(0);
-    opacity: 0;
-    pointer-events: none;
-  }
-  
-  /* When panels are open, they should be visible */
-  body.history-open #historyBox {
-    transform: scale(1);
-    opacity: 1;
-    pointer-events: auto;
-  }
-  
-  body.definition-open #definitionBox {
-    transform: scale(1);
-    opacity: 1;
-    pointer-events: auto;
-  }
-  
-  body.chat-open #chatBox {
-    transform: scale(1);
-    opacity: 1;
-    pointer-events: auto;
   }
 }

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -2,17 +2,42 @@
    Layout - Responsive positioning and panel layouts
    ───────────────────────────────────────────── */
 
+body {
+  --left-panel-width: 0px;
+  --right-panel-width: 0px;
+  --left-panel-gap: 0px;
+  --right-panel-gap: 0px;
+}
+
+body.history-open {
+  --left-panel-width: clamp(220px, 18vw, 280px);
+  --left-panel-gap: 20px;
+}
+
+body.definition-open,
+body.chat-open {
+  --right-panel-width: clamp(220px, 18vw, 280px);
+  --right-panel-gap: 20px;
+}
+
 /* Three-panel layout structure for non-mobile */
 #gameLayoutContainer {
-  display: flex;
+  display: grid;
+  grid-template-columns:
+    minmax(0, var(--left-panel-width))
+    minmax(0, var(--left-panel-gap))
+    minmax(0, 1fr)
+    minmax(0, var(--right-panel-gap))
+    minmax(0, var(--right-panel-width));
+  column-gap: 0;
+  row-gap: 0;
   width: 100%;
   height: 100%;
-  gap: 20px;
   align-items: flex-start;
   justify-content: center;
   position: relative;
   /* Enhanced transitions for smooth layout mode changes */
-  transition: flex-direction 0.3s ease-in-out, 
+  transition: grid-template-columns 0.3s ease-in-out,
               gap 0.3s ease-in-out,
               padding 0.3s ease-in-out;
 }
@@ -20,50 +45,37 @@
 .layout-panel {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 20px;
+  min-width: 0;
   /* Enhanced transitions for panel visibility and layout changes */
-  transition: width 0.3s ease-in-out, 
-              opacity 0.3s ease-in-out,
+  transition: opacity 0.3s ease-in-out,
               transform 0.3s ease-in-out;
 }
 
 #leftPanel {
-  width: 280px;
-  min-width: 280px;
-  position: relative;
-  /* Enhanced panel transitions with transform support */
-  transition: width 0.3s ease-in-out, 
-              opacity 0.3s ease-in-out,
-              transform 0.3s ease-in-out;
-}
-
-#centerPanel {
-  flex: 1;
-  max-width: calc(var(--board-width) + 200px); /* Allow extra buffer around board plus stamp space to prevent history panel overlap at ultra-wide resolutions */
-  min-width: var(--board-width);
-  position: relative;
-  /* Enhanced panel transitions for responsive scaling */
-  transition: width 0.3s ease-in-out, 
-              max-width 0.3s ease-in-out, 
-              min-width 0.3s ease-in-out,
-              transform 0.3s ease-in-out;
+  grid-column: 1;
 }
 
 #rightPanel {
-  width: 280px;
-  min-width: 280px;
+  grid-column: 5;
+}
+
+#centerPanel {
   position: relative;
-  /* Enhanced panel transitions with transform support */
-  transition: width 0.3s ease-in-out, 
-              opacity 0.3s ease-in-out,
-              transform 0.3s ease-in-out;
+  max-width: calc(var(--board-width) + 200px);
+  min-width: min(calc(var(--board-width) + 40px), 100%);
+  justify-self: center;
+  grid-column: 3;
 }
 
 /* Mobile layout will be handled in responsive.css to avoid conflicts */
 
 /* Panel positioning and layout */
 #historyBox {
-  width: 260px;
+  width: 100%;
+  max-width: 100%;
   max-height: calc(100vh - 160px);
   background: var(--bg-color);
   border-radius: 20px;
@@ -83,13 +95,12 @@
               transform 0.3s ease-in-out,
               width 0.3s ease-in-out;
   pointer-events: none;
-  /* Position within left panel on non-mobile */
-  position: relative;
-  top: 10px;
+  margin-top: 10px;
 }
 
 #definitionBox {
-  width: 260px;
+  width: 100%;
+  max-width: 100%;
   max-height: calc(100vh - 160px);
   background: var(--bg-color);
   border-radius: 20px;
@@ -109,24 +120,24 @@
               transform 0.3s ease-in-out,
               width 0.3s ease-in-out;
   pointer-events: none;
-  /* Position within right panel on non-mobile */
-  position: relative;
-  top: 10px;
+  margin-top: 10px;
 }
 
 #chatBox {
-  width: 260px;
-  height: calc(100vh - 160px);
+  width: 100%;
+  max-width: 100%;
+  max-height: calc(100vh - 160px);
   background: var(--bg-color);
   border-radius: 20px;
   padding: 20px;
-  box-shadow: 
+  box-shadow:
     inset 4px 4px 8px var(--inset-shadow-dark),
     inset -4px -4px 8px var(--inset-shadow-light),
     8px 8px 16px var(--shadow-color-dark),
     -8px -8px 16px var(--shadow-color-light);
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   overflow: hidden;
   z-index: var(--z-panel-base);
   opacity: 0;
@@ -137,9 +148,7 @@
               transform 0.3s ease-in-out,
               width 0.3s ease-in-out;
   pointer-events: none;
-  /* Position within right panel on non-mobile */
-  position: relative;
-  top: 10px;
+  margin-top: 10px;
 }
 
 /* Panel visibility states */
@@ -252,10 +261,13 @@ body.chat-open #chatBox {
 
 /* Medium mode panel positioning moved to responsive.css for proper CSS loading order */
 
-body[data-mode='medium'] #historyBox,
+body[data-mode='medium'] #historyBox {
+  transform-origin: top left;
+}
+
 body[data-mode='medium'] #definitionBox,
 body[data-mode='medium'] #chatBox {
-  transform-origin: top left;
+  transform-origin: top right;
 }
 
 body[data-mode='medium']:not(.history-open) #historyBox,

--- a/frontend/static/css/modern-responsive.css
+++ b/frontend/static/css/modern-responsive.css
@@ -224,26 +224,4 @@
 .fluid-space-lg { margin: clamp(1.5rem, 3vw, 3rem); }
 .fluid-space-xl { margin: clamp(2rem, 4vw, 4rem); }
 
-/* ═══════════════════════════════════════════════
-   MEDIUM MODE FIX: Panel positioning to prevent extra space
-   ═══════════════════════════════════════════════ */
-@media (min-width: 601px) and (max-width: 900px) {
-  /* Fix medium mode panel positioning to prevent space above lobbyHeader */
-  body[data-mode='medium'] #historyBox,
-  body[data-mode='medium'] #definitionBox,
-  body[data-mode='medium'] #chatBox {
-    position: absolute !important;
-    top: 10px !important;
-  }
-
-  body[data-mode='medium'] #historyBox {
-    left: 0 !important;
-    transform-origin: left center !important;
-  }
-
-  body[data-mode='medium'] #definitionBox,
-  body[data-mode='medium'] #chatBox {
-    right: 0 !important;
-    transform-origin: right center !important;
-  }
-}
+/* Medium mode layout handled in responsive.css */

--- a/frontend/static/css/responsive.css
+++ b/frontend/static/css/responsive.css
@@ -46,8 +46,7 @@
 
   /* Layout container mobile behavior */
   #gameLayoutContainer {
-    flex-direction: column;
-    gap: 0;
+    display: block;
   }
   
   #leftPanel,
@@ -85,6 +84,7 @@
     pointer-events: none;
     top: auto; /* Reset top for mobile */
     height: auto; /* Reset height for mobile */
+    margin-top: 0;
   }
 
   #definitionBox {
@@ -105,6 +105,7 @@
     pointer-events: none;
     top: auto; /* Reset top for mobile */
     height: auto; /* Reset height for mobile */
+    margin-top: 0;
   }
 
   #chatBox {
@@ -126,6 +127,7 @@
     pointer-events: none;
     top: auto; /* Reset top for mobile */
     height: auto; /* Reset height for mobile */
+    margin-top: 0;
   }
 
   /* Enhanced keyboard handling with modern viewport units */
@@ -665,32 +667,15 @@
     display: none;
   }
 
-  #historyBox,
-  #definitionBox,
-  #chatBox {
-    width: clamp(14rem, 30vw, 17rem);
+  body.history-open {
+    --left-panel-width: clamp(180px, 32vw, 220px);
+    --left-panel-gap: 16px;
   }
 
-  /* Fix medium mode panel positioning to prevent space above lobbyHeader */
-  body[data-mode='medium'] #historyBox {
-    position: absolute !important;
-    top: 10px !important;
-    left: 0 !important;
-  }
-
-  body[data-mode='medium'] #definitionBox {
-    position: absolute !important;
-    top: 10px !important;
-    right: 0 !important;
-  }
-
-  body[data-mode='medium'] #chatBox {
-    position: absolute !important;
-    top: 10px !important;
-    right: 0 !important;
-    left: auto !important; /* Ensure left is not set by other rules */
-    width: clamp(14rem, 30vw, 17rem) !important; /* Match other medium mode panels */
-    transform-origin: right center !important; /* Consistent with large screen mode */
+  body.definition-open,
+  body.chat-open {
+    --right-panel-width: clamp(180px, 32vw, 220px);
+    --right-panel-gap: 16px;
   }
 
   /* Override base positioning for medium mode */

--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -197,40 +197,15 @@ export function positionSidePanels(boardArea, historyBox, definitionBox, chatBox
  * with a small gap, regardless of the definition panel's content height.
  */
 export function updateChatPanelPosition() {
-  const viewportWidth = window.innerWidth;
-  
-  // Only apply dynamic positioning for large screens (≥901px)
-  if (viewportWidth <= 900) {
-    return;
-  }
-  
-  const definitionBox = document.getElementById('definitionBox');
   const chatBox = document.getElementById('chatBox');
-  
-  if (!definitionBox || !chatBox) {
+
+  if (!chatBox) {
     return;
   }
-  
-  // Get the definition panel's position and actual height
-  const definitionRect = definitionBox.getBoundingClientRect();
-  const definitionComputedStyle = window.getComputedStyle(definitionBox);
-  const definitionTop = parseInt(definitionComputedStyle.top, 10) || 180; // fallback to CSS default
-  
-  // Calculate the bottom position of the definition panel
-  // Use scrollHeight to get the actual content height, but respect max-height
-  const maxHeight = parseInt(definitionComputedStyle.maxHeight, 10) || 300;
-  const actualContentHeight = Math.min(definitionBox.scrollHeight, maxHeight);
-  
-  // Position chat panel just below definition panel with 10px gap
-  const chatTop = definitionTop + actualContentHeight + 10;
-  
-  // Set the chat panel position
-  chatBox.style.top = `${chatTop}px`;
-  
-  // Adjust max-height to ensure chat panel doesn't extend beyond viewport
-  const remainingViewportHeight = window.innerHeight - chatTop - 20; // 20px bottom margin
-  const newMaxHeight = Math.max(100, remainingViewportHeight); // Minimum 100px height
-  chatBox.style.maxHeight = `${newMaxHeight}px`;
+
+  // Clear any inline positioning styles so CSS grid/flex layout can handle stacking.
+  chatBox.style.top = '';
+  chatBox.style.maxHeight = '';
 }
 
 


### PR DESCRIPTION
## Summary
- embed the history, definition, and chat panels directly inside the layout columns so they participate in the grid layout
- replace the flex-based layout with CSS grid sizing variables and rework the board area so the stamp rail sits beside the board without overlap
- simplify responsive rules and chat positioning by removing absolute panel overrides in favour of the new grid system

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d568370394832fb51f0eaf44e8bf4f