### PR TITLE
Stabilize light mobile layout and keyboard handling

### DIFF
--- a/frontend/static/css/base.css
+++ b/frontend/static/css/base.css
@@ -77,7 +77,7 @@ body {
   text-align: center;
   background-color: var(--bg-color);
   color: var(--text-color);
-  height: calc(var(--vh, 1vh) * 100);
+  height: var(--keyboard-safe-height, var(--viewport-height, 100vh));
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -94,8 +94,7 @@ body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  min-height: var(--keyboard-safe-height, 100vh); /* Modern viewport with keyboard support */
-  min-height: calc(var(--vh, 1vh) * 100); /* Fallback */
+  min-height: var(--keyboard-safe-height, var(--viewport-height, 100vh)); /* Modern viewport with keyboard support */
   
   /* Enable container queries */
   container-type: inline-size;

--- a/frontend/static/css/components/keyboard.css
+++ b/frontend/static/css/components/keyboard.css
@@ -25,24 +25,11 @@
 }
 
 /* Mobile devices should match board width exactly */
-@media (max-width: 600px) {
-  #appContainer #keyboard {
-    max-width: none; /* Remove max-width constraint on mobile */
-    width: var(--board-width) !important; /* Match the board width exactly */
-    display: block !important; /* Change to block for better width control */
-    margin: 0 auto !important; /* Center the keyboard when it's narrower than container */
-    /* Override any scaling transforms from responsive.css to maintain exact board width */
-    transform: none !important;
-    transform-origin: center center !important;
-  }
-}
-
 /* Ensure keyboard container has proper flexbox behavior */
 #gameColumn {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  min-height: calc(var(--vh, 1vh) * 100);
+  min-height: var(--keyboard-safe-height, var(--viewport-height, 100vh));
 }
 
 /* Keyboard should stick to bottom */

--- a/frontend/static/css/responsive.css
+++ b/frontend/static/css/responsive.css
@@ -37,70 +37,106 @@
    LIGHT MODE: Mobile Layout (≤600px)
    ═══════════════════════════════════════════════ */
 @media (max-width: 600px) {
-  /* Mobile scaling variables */
   :root {
-    /* Mobile scaling - use enhanced scaling values when available */
     --tile-size: var(--current-tile-size, min(8vmin, 32px));
     --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
   }
 
-  /* Layout container mobile behavior - Updated for Grid */
-  /* Note: Grid structure defined in layout.css, mode adaptations here */
-  
-  /* Legacy containers removed - now using CSS Grid exclusively */
-  
+  #appContainer {
+    padding: 8px;
+    gap: 8px;
+    min-height: var(--keyboard-safe-height, var(--viewport-height, 100vh));
+  }
+
+  #mainGrid {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    grid-template-areas: "center";
+    gap: 0;
+  }
+
   #centerPanel {
     width: 100%;
-    max-width: none;
+    max-width: var(--board-width);
     min-width: auto;
   }
 
-  #appContainer {
-    padding: 5px;
-    min-height: var(--keyboard-safe-height, calc(var(--vh, 1vh) * 100));
+  #gameColumn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    min-height: var(--keyboard-safe-height, var(--viewport-height, 100vh));
   }
 
-  /* Mobile panel positioning - panels become fixed overlays on mobile */
-  #historyBox {
-    position: fixed;
-    bottom: 0;
-    left: 0;
+  #boardArea {
+    order: 1;
     width: 100%;
-    max-height: 0;
-    overflow-y: hidden;
-    border-radius: 0;
-    padding: 0;
-    box-shadow: none;
-    background: var(--bg-color);
-    opacity: 0;
-    transform-origin: bottom center;
-    transform: scale(0);
-    z-index: var(--z-mobile-menu);
-    pointer-events: none;
-    top: auto; /* Reset top for mobile */
-    height: auto; /* Reset height for mobile */
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    flex: 0 0 auto;
+    min-height: auto;
+    height: auto;
   }
 
-  #definitionBox {
+  #board {
+    grid-template-columns: repeat(5, var(--tile-size));
+    grid-gap: var(--tile-gap);
+    width: var(--board-width);
+    max-width: var(--board-width);
+    margin: 0 auto;
+  }
+
+  #keyboard {
+    order: 3;
+    width: var(--board-width);
+    max-width: 100%;
+    flex: 0 0 auto;
+    margin: 4px auto max(env(safe-area-inset-bottom, 0px), env(keyboard-inset-height, 0px));
+    position: relative;
+    z-index: var(--z-keyboard);
+    transform: none !important;
+    transform-origin: center bottom !important;
+  }
+
+  #inputArea {
+    display: none !important;
+  }
+
+  #resetWrapper {
+    position: static !important;
+    order: 0 !important;
+    margin: 0 !important;
+    isolation: auto !important;
+  }
+
+  #optionsMenu {
     position: fixed;
-    bottom: 0;
-    right: 0;
-    width: 100%;
-    max-height: 0;
-    overflow-y: hidden;
-    border-radius: 0;
-    padding: 0;
-    box-shadow: none;
-    background: var(--bg-color);
-    opacity: 0;
-    transform-origin: bottom center;
-    transform: scale(0);
-    z-index: var(--z-mobile-menu);
-    pointer-events: none;
-    top: auto; /* Reset top for mobile */
-    height: auto; /* Reset height for mobile */
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
   }
 
+  #optionsToggle,
+  #chatNotify,
+  #hostControls,
+  #lobbyCode,
+  #playerCount {
+    display: none !important;
+  }
+
+  #mobileMenuToggle {
+    display: block !important;
+    position: fixed !important;
+    top: 10px !important;
+    right: 10px !important;
+    z-index: var(--z-mobile-menu) !important;
+    font-size: 18px !important;
+  }
+
+  #historyBox,
+  #definitionBox,
   #chatBox {
     position: fixed;
     bottom: 0;
@@ -114,46 +150,50 @@
     box-shadow: none;
     background: var(--bg-color);
     opacity: 0;
-    transform-origin: bottom center;
-    transform: scale(0);
-    z-index: 10000; /* Increased z-index to appear above virtual keyboards */
-    display: flex;
-    flex-direction: column;
+    z-index: var(--z-mobile-menu);
     pointer-events: none;
-    top: auto; /* Reset top for mobile */
-    height: auto; /* Reset height for mobile */
-  }
-
-  /* Enhanced keyboard handling with modern viewport units */
-  #keyboard {
-    min-height: calc(var(--tile-size) * 2.2);
-    margin-top: 5px;
-    margin-bottom: max(env(safe-area-inset-bottom, 0px), env(keyboard-inset-height, 0px));
-    position: relative;
-    z-index: 100;
-    flex-shrink: 0;
-    transform: scale(var(--keyboard-scale, 1));
-    transform-origin: center bottom;
-  }
-
-  /* Enhanced gameColumn with modern viewport support */
-  #gameColumn {
-    min-height: var(--keyboard-safe-height, calc(var(--vh, 1vh) * 100));
+    transform: none;
+    height: auto;
     display: flex;
     flex-direction: column;
   }
 
-  /* Improved board area with container queries */
-  #boardArea {
-    flex: 0 0 auto;
-    min-height: auto; /* Calculate height based on content */
-    height: auto; /* Allow height to be calculated from board content */
+  body.history-open #historyBox {
+    max-height: 50vh;
+    padding: 12px;
+    overflow-y: auto;
+    opacity: 1;
+    pointer-events: auto;
+    transition: max-height 0.3s ease, opacity 0.3s ease;
   }
 
-  /* Enhanced mobile tile sizing */
-  :root {
-    --tile-size: var(--current-tile-size, min(8vmin, 32px));
-    --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
+  body.definition-open #definitionBox {
+    max-height: 50vh;
+    padding: 12px;
+    overflow-y: auto;
+    opacity: 1;
+    pointer-events: auto;
+    transition: max-height 0.3s ease, opacity 0.3s ease;
+  }
+
+  body.chat-open #chatBox {
+    max-height: 45vh;
+    padding: 36px 12px 12px;
+    overflow: hidden;
+    opacity: 1;
+    pointer-events: auto;
+    transition: max-height 0.3s ease, opacity 0.3s ease;
+  }
+
+  #historyBox h3 {
+    display: none;
+  }
+
+  .history-item .history-guess-tiles .tile {
+    width: 20px;
+    height: 20px;
+    font-size: 12px;
+    line-height: 20px;
   }
 
   .tile {
@@ -169,277 +209,29 @@
     font-size: max(12px, calc(var(--tile-size) * 0.27));
   }
 
-  #appContainer {
-    padding: 5px;
-    min-height: 100vh;
-    min-height: calc(var(--vh, 1vh) * 100);
-  }
-
-  #optionsMenu {
-    position: fixed;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-  }
-
-  #optionsToggle {
-    display: none !important; /* Hidden on mobile - replaced by mobile menu */
-  }
-  
-  #chatNotify {
-    display: none !important; /* Hidden on mobile - replaced by mobile menu */
-  }
-
-  #mobileMenuToggle {
-    display: block !important;
-    position: fixed !important;
-    top: 10px !important;
-    right: 10px !important;
-    z-index: 70 !important;
-    font-size: 18px !important;
-  }
-
-  /* Hide duplicate host control buttons on mobile - they're now in the mobile menu */
-  #hostControls {
-    display: none !important;
-  }
-
-  /* Hide lobby code on mobile since it's now in the title */
-  #lobbyCode {
-    display: none !important;
-  }
-
-  /* Hide player count in mobile/light mode to save space */
-  #playerCount {
-    display: none;
-  }
-
-  /* Open states for mobile panels */
-  body.history-open #historyBox {
-    max-height: 50vh;
-    max-width: calc(98% - 20px);
-    padding: 8px;
-    overflow-y: auto;
-    border-radius: 0;
-    box-shadow: inset 2px 2px 4px var(--shadow-color-dark),
-                inset -2px -2px 4px var(--shadow-color-light);
-    opacity: 1;
-    transform: scale(1);
-    transition: transform 0.3s ease, opacity 0.3s ease;
-    pointer-events: auto;
-  }
-
-  body.definition-open #definitionBox {
-    display: block;
-    max-width: calc(98% - 20px);
-    padding: 8px;
-    overflow-y: auto;
-    border-radius: 0;
-    box-shadow: inset 2px 2px 4px var(--shadow-color-dark),
-                inset -2px -2px 4px var(--shadow-color-light);
-    opacity: 1;
-    transform: scale(1);
-    transition: transform 0.3s ease, opacity 0.3s ease;
-    pointer-events: auto;
-  }
-
-  body.chat-open #chatBox {
-    display: flex;
-    max-height: 40vh;
-    max-width: calc(95% - 20px);
-    margin-left: 10px;
-    padding: 36px 8px 8px;
-    overflow: hidden;
-    border-radius: 0;
-    box-shadow: inset 2px 2px 4px var(--shadow-color-dark),
-                inset -2px -2px 4px var(--shadow-color-light);
-    opacity: 1;
-    transform: scale(1);
-    transition: transform 0.3s ease, opacity 0.3s ease;
-    flex-direction: column;
-    pointer-events: auto;
-  }
-
-  #historyBox h3 {
-    display: none;
-  }
-
-  .history-item .history-guess-tiles .tile {
-    width: 20px;
-    height: 20px;
-    font-size: 12px;
-    line-height: 20px;
-  }
-
-  /* Mobile tile and layout sizing */
-  :root {
-    /* Mobile devices - smaller tiles to ensure keyboard visibility */
-    --tile-size: min(8vmin, 32px);
-    --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
-  }
-
-  #board {
-    grid-template-columns: repeat(5, var(--tile-size));
-    grid-gap: var(--tile-gap);
-    margin: 0;
-  }
-
-  .tile {
-    width: var(--tile-size);
-    height: var(--tile-size);
-    font-size: calc(var(--tile-size) * 0.44);
-    border-radius: 4px;
-    box-shadow: 3px 3px 6px var(--shadow-color-dark),
-                -3px -3px 6px var(--shadow-color-light);
-  }
-
-  /* Mobile reset button positioning - move to top left */
-  #resetWrapper {
-    position: fixed !important;
-    top: 10px !important;
-    left: 10px !important;
-    z-index: 999 !important; /* Extremely high z-index to ensure it's always on top */
-    order: unset !important;
-    margin: 0 !important;
-    pointer-events: auto !important; /* Ensure it can receive touch events */
-    /* Create new stacking context to ensure proper layering */
-    isolation: isolate !important;
-  }
-
-  /* Mobile header uniformity - match hamburger menu button height */
-  #holdReset {
-    height: 44px !important;
-    width: 44px !important;
-    font-size: 14px !important;
-    z-index: 999 !important; /* Ensure button itself is above leaderboard */
-    position: relative !important; /* Ensure proper stacking context */
-    pointer-events: auto !important; /* Ensure it can receive touch events */
-    touch-action: manipulation !important; /* Optimize for touch interaction */
-    /* Create new stacking context to isolate from other elements */
-    isolation: isolate !important;
-  }
-
-  /* Hide input area on mobile since users should use on-screen keyboard */
-  #inputArea {
-    display: none !important; /* Hide input area on mobile - users should use on-screen keyboard */
-  }
-
   #messagePopup {
     font-size: 16px;
   }
 
-  /* Points popup mobile positioning */
   #pointsPopup {
     top: 20%;
     font-size: 20px;
     padding: 10px 16px;
-    /* Better mobile positioning */
     max-width: calc(100vw - 40px);
     text-align: center;
   }
 
-  /* Enhanced mobile keyboard adjustments with virtual keyboard support */
-  #keyboard {
-    min-height: calc(var(--tile-size) * 2.2);
-    margin-bottom: max(env(safe-area-inset-bottom, 0px), env(keyboard-inset-height, 0px));
-    /* Ensure keyboard is always visible above virtual keyboard */
-    position: relative;
-    z-index: 100;
-    flex-shrink: 0;
-    transform: scale(var(--keyboard-scale, 1));
-    transform-origin: center bottom;
-  }
-
-  /* Enhanced gameColumn with modern viewport support */
-  #gameColumn {
-    min-height: var(--keyboard-safe-height, calc(var(--vh, 1vh) * 100));
-    display: flex;
-    flex-direction: column;
-  }
-
-  /* Board area should only take space it needs, not expand */
-  #boardArea {
-    flex: 0 0 auto; /* Only take space needed, don't expand */
-    min-height: auto; /* Calculate height based on content */
-    height: auto; /* Allow height to be calculated from board content */
-  }
-
-  /* Ensure input area doesn't take excessive space */
-  #inputArea {
-    flex: 0 0 auto; /* Don't allow expansion */
-    margin: 3px auto 3px; /* Reduced margins to keep keyboard closer to board */
-  }
-
-  /* Keep message areas compact */
-  #message {
-    flex: 0 0 auto;
-    margin: 3px 0; /* Reduced margin */
-  }
-
-  #messagePopup {
-    flex: 0 0 auto;
-  }
-
-  /* Position keyboard immediately after other elements */
-  #keyboard {
-    flex: 0 0 auto; /* Don't shrink or expand */
-    margin-top: 3px; /* Reduced margin to position closer to board */
-    order: 999; /* Ensure keyboard comes last in flex order */
-  }
-
-  .key {
-    min-width: calc(var(--tile-size) * 0.58);
-    height: calc(var(--tile-size) * 0.83);
-    margin: calc(var(--tile-gap) / 2);
-    font-size: calc(var(--tile-size) * 0.27);
-    padding: 0 5px;
-    box-shadow: 3px 3px 6px var(--shadow-color-dark),
-                -3px -3px 6px var(--shadow-color-light);
-    border-radius: 6px;
-  }
-
-  .key.wide {
-    min-width: calc(var(--tile-size) * 1.2);
-  }
-
-  /* Mobile reset button - now uses unified sizing */
-
-  .leaderboard-entry {
-    font-size: calc(1em * var(--ui-scale));
-    padding: calc(5px * var(--ui-scale)) calc(10px * var(--ui-scale));
-    margin: 0 3px;
-    min-width: calc(40px * var(--ui-scale));
-  }
-
-  .hint-badge {
-    margin-left: 4px;
-    font-size: calc(0.7em * var(--ui-scale));
-    animation: hint-pulse 4s ease-in-out infinite;
-  }
-
-  h1 {
-    font-size: calc(1.5em * var(--ui-scale));
-    margin-bottom: 2px;
-  }
-  
-  #message {
-    font-size: 16px;
-    margin-top: 12px;
-  }
-
-  /* Additional mobile layout fixes */
   #titleBar {
     flex-direction: column;
     gap: 0.5rem;
     align-items: center;
   }
-  
+
   #titleBar h1 {
     font-size: 1.5rem;
     margin: 0;
   }
-  
-  /* Mobile leaderboard inline with title */
+
   #titleBar .mobile-title-row {
     display: flex;
     flex-direction: row;
@@ -449,18 +241,17 @@
     gap: 0.5rem;
     position: relative;
   }
-  
+
   #titleBar .mobile-title-row h1 {
     margin: 0;
     text-align: center;
-    /* Scale down title to always fit on one line */
     font-size: clamp(1.1rem, 4.5vw, 1.5rem);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 60vw;
   }
-  
+
   #titleBar .mobile-leaderboard-container {
     position: absolute;
     right: 0;
@@ -469,14 +260,14 @@
     min-width: 0;
     overflow: hidden;
     max-width: 200px;
-    z-index: 70; /* Below reset button (85) but above other UI elements */
+    z-index: 70;
   }
-  
+
   #titleBar .mobile-leaderboard-container #leaderboard {
     margin: 0;
     padding: 0;
     gap: 8px;
-    max-height: 60px; /* Increased to prevent emoji clipping on mobile */
+    max-height: 60px;
     overflow-x: auto;
     overflow-y: hidden;
     flex-wrap: nowrap;
@@ -485,37 +276,33 @@
     -webkit-overflow-scrolling: touch;
     display: flex;
   }
-  
+
   #titleBar .mobile-leaderboard-container #leaderboard::-webkit-scrollbar {
     display: none;
   }
-  
+
   #titleBar .mobile-leaderboard-container #leaderboard {
     -ms-overflow-style: none;
     scrollbar-width: none;
   }
-  
-  /* Hide the separate leaderboard on mobile when it's moved inline */
+
   body:has(.mobile-leaderboard-container #leaderboard) > #appContainer > #leaderboard:not(.mobile-inline) {
     display: none;
   }
-  
-  /* Ensure leaderboard entries are appropriately sized for mobile inline */
+
   #titleBar .mobile-leaderboard-container .leaderboard-entry {
-    /* Limit scaling to prevent tiles from exceeding 44px height */
     font-size: min(calc(0.9em * var(--ui-scale)), 14px);
     padding: min(calc(4px * var(--ui-scale)), 6px) min(calc(8px * var(--ui-scale)), 8px);
     margin: 0 2px;
     min-width: calc(35px * var(--ui-scale));
     white-space: nowrap;
     flex-shrink: 0;
-    /* Mobile header uniformity - match hamburger menu button height */
     height: 44px !important;
-    max-height: 44px !important; /* Enforce maximum height */
+    max-height: 44px !important;
     box-sizing: border-box;
     display: flex;
     align-items: center;
-    overflow: hidden; /* Prevent content overflow */
+    overflow: hidden;
   }
 }
 

--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -155,14 +155,10 @@ export function setGameInputDisabled(disabled) {
 export function updateVH() {
   const height = window.visualViewport ? window.visualViewport.height : window.innerHeight;
   const vh = height * 0.01;
-  document.documentElement.style.setProperty('--vh', `${vh}px`);
+  const root = document.documentElement;
 
-  const container = document.getElementById('appContainer');
-  if (container) {
-    // Use the visual viewport height for better mobile experience
-    container.style.height = `${height}px`;
-    container.style.minHeight = `${height}px`;
-  }
+  root.style.setProperty('--vh', `${vh}px`);
+  root.style.setProperty('--viewport-height', `${height}px`);
 
   const board = document.getElementById('board');
   if (board) {


### PR DESCRIPTION
## Summary
- Consolidate ≤600px layout rules for the grid, board area, overlays, keyboard, and menus into a single mobile stylesheet block
- Align viewport handling by having updateVH feed shared CSS vars and rely on keyboard-safe height for stacking content above the on-screen keyboard
- Simplify mobile overlays and controls so board/keyboard order, reset placement, and hidden desktop inputs no longer conflict across files

## Testing
- Not run (not requested)

Do not add or modify any tests or Markdown/MD files in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa35de120832f9d5caf3892ef0cb4)