### PR TITLE
Align input area with board sizing

### DIFF
--- a/frontend/static/css/base.css
+++ b/frontend/static/css/base.css
@@ -30,9 +30,14 @@
   --ui-scale: var(--current-scale-factor, 1);
   --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
   
+  /* Shared spacing tokens */
+  --component-gap: clamp(0.25rem, 1vw, 1rem);
+  --component-gap-tight: calc(var(--component-gap) * 0.6);
+  --input-inline-gap: calc(var(--tile-gap) * 2);
+  
   /* Uniform button sizing - ensures buttons are same size */
-  --uniform-button-width: calc(var(--tile-size) * 1.8);
-  --uniform-button-height: calc(var(--tile-size) * 0.8);
+  --uniform-button-width: max(calc(var(--tile-size) * 1.8), var(--min-touch-target));
+  --uniform-button-height: max(calc(var(--tile-size) * 0.8), var(--min-touch-target));
   
   /* Modern viewport support */
   --viewport-height: var(--dynamic-viewport-height, 100vh);
@@ -109,7 +114,7 @@ body {
   width: 100%;
   align-items: center;
   justify-content: flex-start;
-  gap: 8px; /* Add consistent spacing between elements */
+  gap: var(--component-gap); /* Add consistent spacing between elements */
 }
 
 h1 {

--- a/frontend/static/css/components/board.css
+++ b/frontend/static/css/components/board.css
@@ -7,7 +7,7 @@
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  margin: 5px auto 0;
+  margin: 0 auto;
   width: 100%;
   position: relative;
   flex: 0 0 auto; /* Only take space needed, don't expand */
@@ -19,7 +19,7 @@
     /* Don't constrain width - let it use the full game column space */
     width: 100%;
     max-width: 100%; /* Use full width of parent container (gameColumn) */
-    margin: 5px auto 0;
+    margin: 0 auto;
   }
 }
 
@@ -208,10 +208,11 @@ body.hint-selecting .tile:not(.hint-target) {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 5px auto;
+  margin: 0 auto;
   width: var(--board-width);
+  max-width: var(--board-width);
   flex: 0 0 auto;
-  gap: calc(var(--tile-gap) * 2);
+  gap: var(--input-inline-gap);
 }
 
 #guessInput,
@@ -223,11 +224,12 @@ body.hint-selecting .tile:not(.hint-target) {
   color: var(--text-color);
   outline: none;
   transition: box-shadow 0.2s, background-color 0.3s, color 0.3s;
+  box-sizing: border-box;
 }
 
 #guessInput {
   /* Calculate input width: board width minus 2 buttons and gaps */
-  width: calc(var(--board-width) - (var(--uniform-button-width) * 2) - (var(--tile-gap) * 4));
+  width: calc(var(--board-width) - (var(--uniform-button-width) * 2) - (var(--input-inline-gap) * 2));
   height: var(--uniform-button-height);
   padding: 0 calc(var(--tile-size) * 0.2);
   text-transform: uppercase;

--- a/frontend/static/css/components/modals.css
+++ b/frontend/static/css/components/modals.css
@@ -63,8 +63,6 @@
   transition: opacity 0.3s ease-in-out;
   pointer-events: none;
 }
-  justify-content: center;
-}
 
 #closeCallBox {
   background: var(--bg-color);

--- a/frontend/static/css/responsive.css
+++ b/frontend/static/css/responsive.css
@@ -65,7 +65,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 8px;
+    gap: var(--component-gap);
     min-height: var(--keyboard-safe-height, var(--viewport-height, 100vh));
   }
 
@@ -521,9 +521,9 @@
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    margin-bottom: 8px;
     width: var(--board-width);
-    gap: calc(var(--tile-gap) * 2);
+    max-width: var(--board-width);
+    gap: var(--input-inline-gap);
     flex: 0 0 auto; /* Don't allow input area to shrink */
   }
 }

--- a/frontend/static/js/utils.js
+++ b/frontend/static/js/utils.js
@@ -1091,23 +1091,26 @@ function compactLayoutForInputField() {
   
   if (!status.overlap) return;
 
+  const rootStyles = getComputedStyle(document.documentElement);
+  const compactGap = (rootStyles.getPropertyValue('--component-gap-tight') || '').trim() || '6px';
+
   // Reduce margins and padding of elements above the input field
   const titleBar = document.getElementById('titleBar');
   const boardArea = document.getElementById('boardArea');
   
   if (titleBar) {
-    titleBar.style.marginBottom = '5px';
+    titleBar.style.marginBottom = compactGap;
   }
   
   if (boardArea) {
-    boardArea.style.marginBottom = '5px';
+    boardArea.style.marginBottom = compactGap;
   }
 
   // Make the input area more compact
   const inputArea = document.getElementById('inputArea');
   if (inputArea) {
-    inputArea.style.marginTop = '3px';
-    inputArea.style.marginBottom = '3px';
+    inputArea.style.marginTop = compactGap;
+    inputArea.style.marginBottom = compactGap;
   }
 }
 


### PR DESCRIPTION
## Summary
- align the input area layout to the board width using shared spacing tokens and box sizing
- enforce shared button sizing variables with accessible touch-target minimums for guess and reset controls
- remove stray modal CSS that caused build warnings

## Testing
- npm run build

Do not add or modify any tests or Markdown/MD files in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab01ab5b4832f8aa8471d2ae1606a)