### PR TITLE
Improve frontend UX and stabilize test utilities

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -92,16 +92,19 @@ def add_cache_control_headers(response):
     """Add appropriate cache-control headers to responses."""
     # Set different cache policies based on content type and path
     # Override any existing cache-control if needed
-    if request.endpoint in ['index', 'game_page', 'lobby_page']:
+    endpoint = getattr(request, 'endpoint', None)
+    path = getattr(request, 'path', "") or getattr(request, 'url', "")
+
+    if endpoint in ['index', 'game_page', 'lobby_page']:
         # HTML pages - short cache with must-revalidate for freshness
         response.headers['Cache-Control'] = 'public, max-age=300, must-revalidate'
-    elif request.path.startswith('/static/') or request.path.startswith('/assets/'):
+    elif path.startswith('/static/') or path.startswith('/assets/'):
         # Static assets - longer cache for performance
         response.headers['Cache-Control'] = 'public, max-age=86400, immutable'
-    elif request.endpoint in ['js_files', 'css_files', 'asset_files', 'lobby_js_files', 'lobby_css_files', 'lobby_asset_files']:
+    elif endpoint in ['js_files', 'css_files', 'asset_files', 'lobby_js_files', 'lobby_css_files', 'lobby_asset_files']:
         # JS/CSS files - longer cache for performance
         response.headers['Cache-Control'] = 'public, max-age=86400, immutable'
-    elif request.endpoint in ['health', 'state', 'lobby_state', 'chat', 'lobby_chat']:
+    elif endpoint in ['health', 'state', 'lobby_state', 'chat', 'lobby_chat']:
         # API endpoints - no cache to ensure real-time data
         response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
         response.headers['Pragma'] = 'no-cache'

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -22,6 +22,12 @@
 
 <body>
   <div id="appContainer">
+    <div id="waitingOverlay" aria-live="polite">
+      <div class="waiting-content" role="status">
+        <p>Setting up your game. This should only take a moment.</p>
+        <button id="waitingDismiss" type="button">Continue</button>
+      </div>
+    </div>
     <!-- Emoji Picker Modal -->
     <div id="emojiModal" role="dialog" aria-modal="true" aria-labelledby="emojiModalHeading">
       <div id="emojiModalBox">

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -257,6 +257,38 @@ body.chat-open #chatBox {
       ". history stamp center ."
       ". history stamp center .";
   }
+  
+  /* Medium mode overlays when panels are forced into popup mode */
+  body[data-mode='medium'][data-history-popup="true"] #historyBox,
+  body[data-mode='medium'][data-history-popup="true"] #definitionBox,
+  body[data-mode='medium'][data-history-popup="true"] #chatBox {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    max-width: 90%;
+    max-height: 80vh;
+    z-index: var(--z-panel-overlay);
+  }
+  
+  /* Medium mode grid layout keeps history inline but definition/chat as overlays */
+  body[data-mode='medium']:not([data-history-popup="true"]) #historyBox {
+    position: static;
+    transform: none;
+    max-width: var(--panel-width);
+    max-height: var(--panel-max-height);
+  }
+  
+  body[data-mode='medium']:not([data-history-popup="true"]) #definitionBox,
+  body[data-mode='medium']:not([data-history-popup="true"]) #chatBox {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    max-width: 90%;
+    max-height: 80vh;
+    z-index: var(--z-panel-overlay);
+  }
 }
 
 /* ═══════════════════════════════════════════════
@@ -276,6 +308,26 @@ body.chat-open #chatBox {
   }
   
   /* Mobile panels as overlays - positioning handled in responsive.css */
+  body[data-mode='light'] #historyBox {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: auto;
+  }
+  
+  body[data-mode='light'] #definitionBox {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    left: auto;
+  }
+  
+  body[data-mode='light'] #chatBox {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    left: auto;
+  }
 }
 
 /* Popup modals that fill the viewport */
@@ -345,6 +397,71 @@ body.chat-open #chatBox {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease-in-out;
+}
+
+/* Waiting overlay shown while rejoining/connecting */
+#waitingOverlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+  z-index: var(--z-modal-backdrop);
+  transition: opacity 0.25s ease-in-out;
+}
+
+#waitingOverlay.active {
+  pointer-events: auto;
+}
+
+#waitingOverlay .waiting-content {
+  pointer-events: auto;
+  background: var(--bg-color);
+  color: var(--text-color);
+  padding: 16px 20px;
+  border-radius: 16px;
+  box-shadow: 
+    inset 4px 4px 8px var(--inset-shadow-dark),
+    inset -4px -4px 8px var(--inset-shadow-light),
+    6px 6px 14px var(--shadow-color-dark),
+    -6px -6px 14px var(--shadow-color-light);
+  text-align: center;
+}
+
+#waitingOverlay.fade-out {
+  animation: fadeOutOverlay 0.35s ease forwards;
+}
+
+@keyframes fadeOutOverlay {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+/* Extra small device tuning to keep controls usable */
+@media (max-width: 400px) {
+  :root {
+    --tile-size: min(12vmin, 36px);
+    --board-width: calc(var(--tile-size) * 5 + var(--tile-gap) * 4);
+  }
+  
+  #keyboard {
+    min-height: calc(var(--tile-size) * 2);
+    margin-bottom: max(2px, env(safe-area-inset-bottom, 0px));
+    margin-top: 5px;
+  }
+  
+  .key {
+    min-width: calc(var(--tile-size) * 0.58);
+    height: calc(var(--tile-size) * 0.75);
+    font-size: calc(var(--tile-size) * 0.24);
+    margin: 1px;
+  }
+  
+  .keyboard-row {
+    margin-bottom: calc(var(--tile-gap) * 0.8);
+  }
 }
 
 /* Mobile panel positioning moved to responsive.css to avoid conflicts */

--- a/frontend/static/js/domManager.js
+++ b/frontend/static/js/domManager.js
@@ -23,6 +23,8 @@ class DOMManager {
     // Message and popup elements
     this.elements.messageEl = document.getElementById('message');
     this.elements.messagePopup = document.getElementById('messagePopup');
+    this.elements.waitingOverlay = document.getElementById('waitingOverlay');
+    this.elements.waitingDismiss = document.getElementById('waitingDismiss');
     
     // Panel elements
     this.elements.historyBox = document.getElementById('historyBox');

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -26,8 +26,8 @@ check_python_packages() {
 echo "Checking Python..."
 check_cmd python3
 py_version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-if [[ $(python3 -c 'import sys;print(sys.version_info<(3,12))') == "True" ]]; then
-  echo "Python 3.12+ required (found $py_version)" >&2
+if [[ $(python3 -c 'import sys;print(sys.version_info<(3,11))') == "True" ]]; then
+  echo "Python 3.11+ required (found $py_version)" >&2
   exit 1
 fi
 check_python_packages


### PR DESCRIPTION
## Summary
- add waiting overlay, definition handling, responsive tweaks, and options menu positioning to the frontend
- harden layout mode calculations and setup script compatibility
- isolate test server stubs to avoid polluting Flask-based tests and fix cache-control handling

## Testing
- python -m pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ac2feb314832fb7fe39b50ded3295)