### PR TITLE
Improve responsive scaling layout

### DIFF
--- a/docs/RESPONSIVE_SCALING_PLAN.md
+++ b/docs/RESPONSIVE_SCALING_PLAN.md
@@ -1,0 +1,32 @@
+# Responsive Scaling & Test Plan
+
+## Goals
+- Confirm the UI scales cleanly from small phones through ultra-wide desktops.
+- Keep panels, board, and keyboard within the visible viewport at common breakpoints.
+- Ensure automated tests cover layout-critical flows.
+
+## Test Coverage (Small Batches)
+- **Unit/Backend**: `python -m pytest -v`.
+- **Frontend smoke**: open the landing page + game page at common widths (320, 375, 768, 1024, 1440, 1920).
+- **E2E (optional)**: run Playwright/Cypress if browsers are installed.
+
+## Layout Audit Checklist
+- Verify the board fits without horizontal scrolling at each breakpoint.
+- Confirm header, chat/history/definition panels remain reachable.
+- Validate keyboard visibility on mobile (iOS/Android emulation).
+
+## Implementation Steps
+1. **CSS sizing pass**
+   - Use `clamp()` for panel widths and board sizing tokens.
+   - Limit overly wide layouts with a max-width container.
+2. **Viewport spacing**
+   - Ensure fixed headers/footers don’t overlap playable space.
+   - Re-check padding with safe-area insets.
+3. **JS scaling hooks**
+   - Validate resize/orientation handlers still trigger correctly.
+   - Add logs or telemetry only if needed for debugging.
+
+## Post-Change Verification
+- Re-run smoke checks at the listed breakpoints.
+- Capture screenshots for landing + in-game views.
+- Log any device-specific quirks for follow-up tickets.

--- a/frontend/static/css/base.css
+++ b/frontend/static/css/base.css
@@ -126,16 +126,8 @@ body {
   flex-direction: column;
   overflow: hidden;
   min-height: var(--viewport-height); /* Modern viewport with dvh support */
-  /*
-   * Constrain main app content for readability and to match reference layout.
-   * On large / ultra-wide screens, content remains at 980px wide and is
-   * centered in the viewport via margin: 0 auto;, leaving extra space as
-   * background.
-   * Adjust this max-width if we later introduce wider layouts (e.g., sidebars
-   * or full-bleed sections) for >1080p displays.
-   */
-  max-width: 980px;
-  margin: 0 auto;
+  max-width: 100%;
+  margin: 0;
   
   /* Enable container queries */
   container-type: inline-size;

--- a/frontend/static/css/desktop-layout.css
+++ b/frontend/static/css/desktop-layout.css
@@ -38,7 +38,7 @@
      ───────────────────────────────── */
   
   :root {
-    --desktop-panel-width: 240px;
+    --desktop-panel-width: clamp(200px, 18vw, 280px);
     --desktop-stamp-width: 60px;
     --desktop-header-height: 60px;
     --desktop-panel-max-height: calc(100vh - 160px);
@@ -133,6 +133,8 @@
     padding: calc(var(--desktop-header-height) + var(--desktop-grid-gap)) var(--desktop-grid-gap) var(--desktop-grid-gap);
     height: 100vh;
     width: 100%;
+    max-width: min(1400px, 100%);
+    margin: 0 auto;
     box-sizing: border-box;
     overflow: hidden;
     grid-template-areas: "left center right";


### PR DESCRIPTION
### Motivation
- Make the UI reliably scale across small phones, tablets, and large/ultra-wide desktops by removing hard width caps and using responsive sizing tokens.
- Provide a compact test plan to validate layout and viewport behavior across common breakpoints.

### Description
- Relaxed the global app container cap in `frontend/static/css/base.css` by removing the fixed `max-width: 980px` and using `max-width: 100%` with `margin: 0` so layouts can fluidly scale.
- Tuned desktop sizing in `frontend/static/css/desktop-layout.css` by making `--desktop-panel-width` responsive with `clamp(200px, 18vw, 280px)` and constraining the grid with `max-width: min(1400px, 100%)` and centered `margin: 0 auto` to avoid overly wide, unbalanced layouts.
- Added a short, focused planning document `docs/RESPONSIVE_SCALING_PLAN.md` describing goals, quick test coverage, a layout audit checklist, and implementation steps for follow-up validation.

### Testing
- Installed backend dependencies with `python -m pip install -r backend/requirements.txt`, which completed successfully.
- Launched the local server with `python backend/server.py` and confirmed the `/game.html` page served correctly.
- Ran a Playwright smoke script to open `/game.html` at 1280×720 and captured a screenshot (`artifacts/game-desktop.png`) to validate the desktop layout rendering.
- No unit test suite (`pytest`) was executed as part of this change; this is a layout-only update and the plan in `docs/RESPONSIVE_SCALING_PLAN.md` lists recommended automated and manual checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697230692dc4832fb5f4d4c13dcfc235)